### PR TITLE
fix links on shoutem.github.io/ui page

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
 						<h2>Get started now</h2>
 
 						<div class="container">
-							<a class="chapter" href="/docs/getting-started/introduction">
+							<a class="chapter" href="/docs/ui-toolkit/introduction">
 								<div class="chapter-image purple">
 									<img src="images/icon-tutorial-ui-toolkit.svg" />
 								</div>
@@ -303,7 +303,7 @@
 									<p>Build beautiful React Native apps by using our professionally designed UI components.</p>
 								</div>
 							</a>
-							<a class="chapter" href="/docs/ui-toolkit/introduction">
+							<a class="chapter" href="https://github.com/shoutem/ui">
 								<div class="chapter-image black">
 									<img src="images/icon-tutorial-github.svg" />
 								</div>


### PR DESCRIPTION
fixes links on https://shoutem.github.io/ui/ page 

screenshot for reference: http://prntscr.com/cic0ix

first link from commit doesn’t lead anywhere, while 2ndlink should lead
to github, but it leads to docs 