### PR TITLE
Change rnpm link to react-native link

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "mocha -R spec --require test-utils/setup.js --require react-native-mock/mock.js --compilers js:babel-core/register $(find . -name '*.spec.js' ! -ipath '*node_modules*')",
-    "postinstall": "rnpm link"
+    "postinstall": "react-native link"
   },
   "rnpm": {
     "assets": [


### PR DESCRIPTION
RNPM is now built in to react native so use react-native link instead of rnpm link in post install script