### PR TITLE
Fix defaultSource special case for Android

### DIFF
--- a/components/Image.js
+++ b/components/Image.js
@@ -3,9 +3,13 @@ import {
   Image as RNImage,
   Platform,
 } from 'react-native';
+import _ from 'lodash';
 
 import { connectStyle } from '@shoutem/theme';
 import { connectAnimation } from '@shoutem/animation';
+
+// a valid source is either an object with an uri key or a number (from a `require` call)
+const isValidSource = (source) => _.isNumber(source) || (_.isObject(source) && source.uri)
 
 class Image extends Component {
   static propTypes = {
@@ -23,7 +27,7 @@ class Image extends Component {
 
     // defaultSource is not supported on Android, so we manually
     // reassign the defaultSource prop to source if source is not defined
-    if ((Platform.OS === 'android') && (!source || !source.uri)) {
+    if (Platform.OS === 'android' && !isValidSource(source)) {
       resolvedProps = {
         ...props,
         // Image views are not rendered on Android if there is no image to display,


### PR DESCRIPTION
```
<Image source={require('./image.png')} />
```

This relaxes the restriction to allow `Image`s like above.