### PR TITLE
Hide the network indicator when ListView unmounts

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -119,6 +119,13 @@ class ListView extends React.Component {
       (nextState.status !== this.state.status);
   }
 
+  componentWillUnmount() {
+    if ((Platform.OS === 'ios') && (this.state.status !== Status.IDLE)) {
+      // Reset the global network indicator state
+      StatusBar.setNetworkActivityIndicatorVisible(false);
+    }
+  }
+
   onRefresh() {
     this.setState({
       status: Status.REFRESHING,


### PR DESCRIPTION
In some cases the ListView may be unmounted while
a network request is in progress. This caused the
network activity indicator to remain visible until the
next network request.