### PR TITLE
Update package.json

### DIFF
--- a/examples/RestaurantsApp/package.json
+++ b/examples/RestaurantsApp/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@shoutem/ui": "*",
     "react": "~15.3.0",
-    "react-native": "0.32.0",
+    "react-native": "0.35.0",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"


### PR DESCRIPTION
Updated react-native to 0.35.0 to address issues related to linking and CFUBundler not found on MacOSX 10.11 with XCode8 Beta
