### PR TITLE
Exponent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Shoutem UI is a set of styleable components that enables you to build beautiful 
 
 ```
 $ npm install --save @shoutem/ui
-$ react-native link
+$ react-native link # No need to run this with Exponent
 ```
 
 ## Docs
@@ -22,6 +22,10 @@ To see how Shoutem UI works, you can:
 
 ### Examples component
 
+**If you are using Exponent, see [this
+project](https://github.com/exponentjs/shoutem-example/blob/master/main.js)
+for example usage. Otherwise, follow the steps below.**
+
 Create new React Native project:
 
 ```bash
@@ -35,7 +39,8 @@ $ cd HelloWorld
 $ npm install --save @shoutem/ui
 ```
 
-Run `react-native` to link fonts that the toolkit is using:
+Run `react-native` to link fonts that the toolkit is using (skip this if
+you are using Exponent):
 
 ```bash
 $ react-native link
@@ -100,12 +105,12 @@ react-native run-android
 
 ## UI Toolkit
 
-Shoutem UI is a part of the Shoutem UI Toolkit that enables you to build professionally looking React Native apps with ease.  
+Shoutem UI is a part of the Shoutem UI Toolkit that enables you to build professionally looking React Native apps with ease.
 
 It consists of three libraries:
 
 - [@shoutem/ui](https://github.com/shoutem/ui): beautiful and customizable UI components
-- [@shoutem/theme](https://github.com/shoutem/theme): “CSS-way” of styling entire app 
+- [@shoutem/theme](https://github.com/shoutem/theme): “CSS-way” of styling entire app
 - [@shoutem/animation](https://github.com/shoutem/animation): declarative way of applying ready-made  animations
 
 ## License

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "react-native-mock": "^0.2.5"
   },
   "scripts": {
-    "test": "mocha -R spec --require test-utils/setup.js --require react-native-mock/mock.js --compilers js:babel-core/register $(find . -name '*.spec.js' ! -ipath '*node_modules*')",
-    "postinstall": "react-native link"
+    "test": "mocha -R spec --require test-utils/setup.js --require react-native-mock/mock.js --compilers js:babel-core/register $(find . -name '*.spec.js' ! -ipath '*node_modules*')"
   },
   "rnpm": {
     "assets": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "html-entities": "^1.2.0",
     "htmlparser2": "^3.9.0",
     "lodash": "^4.15.0",
-    "react-native-lightbox": "shoutem/react-native-lightbox",
+    "react-native-lightbox": "git+https://github.com/shoutem/react-native-lightbox#master",
     "react-native-maps": "^0.8.2",
     "react-native-share": "^1.0.13",
     "react-native-vector-icons": "^2.0.3",


### PR DESCRIPTION
Hi there! Sorry this took so long :P We just released an update to make react-native-vector-icons play more nicely with Exponent, so now all that's needed is these small changes. We don't support react-native-share either, so maybe at some point that can be removed and replaced with the built-in alternative in React Native, but I didn't bother with that here. Tested it and published to https://getexponent.com/@community/shoutem-ui-examples