### PR TITLE
DropDownMenu animation blinking issue solved.

### DIFF
--- a/components/DropDownMenu.js
+++ b/components/DropDownMenu.js
@@ -204,7 +204,7 @@ class DropDownMenu extends Component {
           transparent
         >
           <ZoomOut driver={this.timingDriver} maxFactor={1.1} style={{ flex: 1 }}>
-            <FadeIn driver={this.timingDriver} style={{ flex: 1 }}>
+            <FadeIn driver={this.timingDriver} style={{ flex: 1, opacity: 0 }}>
               <View style={style.modal} styleName="vertical">
                 <AnimatedListView
                   dataSource={dataSource}


### PR DESCRIPTION
Issue #197 fixed

## Why?
FadeIn is basically increasing opacity with transition. When you FadeIn, animation is setting opacity to 0 and increasing slowly in a while (for this situation, 1 second i guess)

And if you don't set opacity manually, view shows up first and after that FadeIn animation sets it to 0 and starts animation. And it seems blinking effect to user.

## GIF
![giphy-2](https://cloud.githubusercontent.com/assets/22980987/24124473/8b466da8-0dcc-11e7-8837-986f9a5cd1ef.gif)


## Conclusion
I set opacity to 0 at init and that's it. Problem solved. We have much fluent animation now. You can see difference between before and after with comparing gifs (one gif at issue #197).

Test Device: Nexus 5 | Android 6.0