### PR TITLE
Remove 'alignSelf' from centerComponent

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -1289,7 +1289,6 @@ export default (variables = defaultVariables) => ({
     },
 
     centerComponent: {
-      alignSelf: 'center',
       alignItems: 'center',
       flex: 1,
     },


### PR DESCRIPTION
Since centerComponent overrides 'flex-end' vertical alignment set by it's parent and sets it to 'center' for itself, it breaks vertical alignment with it's siblings (leftComponent, righComponent). centerComponent should just receive vertical alignment by it's parent and not override it.