### PR TITLE
Change the default colors for NavigationBar icons and text (title)

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -105,10 +105,10 @@ const defaultVariables = {
     fontFamily: 'Rubik-Regular',
     fontStyle: 'normal',
     fontWeight: 'normal',
-    color: '#666666',
+    color: '#222222',
     fontSize: 15,
   },
-  navBarIconsColor: '#AEAEAE',
+  navBarIconsColor: '#222222',
   featuredNavBarTitleColor: '#ffffff',
   featuredNavBarIconsColor: '#ffffff',
 


### PR DESCRIPTION
Based on this issue https://github.com/shoutem/ui/issues/209 I changed the default colors for NavigationBar icons and text to #222222 (blackish). Heading, title and subtitle style attributes also use this color and it is better to use it in NavigationBar than the previously used #AEAEAE for icons and #666666 for text (title).