### PR TITLE
Export default theme variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 import { setDefaultThemeStyle } from './init';
-import getTheme from './theme';
+import getTheme, { defaultThemeVariables } from './theme';
 
 setDefaultThemeStyle();
 
 // Theme
-export { getTheme };
+export { getTheme, defaultThemeVariables };
 
 // Components
 export { View } from './components/View';

--- a/theme.js
+++ b/theme.js
@@ -52,7 +52,7 @@ function dimensionRelativeToIphone(dimension, actualRefVal = window.width) {
   return getSizeRelativeToReference(dimension, 375, actualRefVal);
 }
 
-const defaultVariables = {
+export const defaultThemeVariables = {
   featuredColor: '#659CEC',
   backgroundColor: '#f2f2f2',
   paperColor: '#FFFFFF',
@@ -141,7 +141,7 @@ const defaultVariables = {
   sectionHeaderBackgroundColor: '#F2F2F2',
 };
 
-export default (variables = defaultVariables) => ({
+export default (variables = defaultThemeVariables) => ({
   //
   // Common
   //


### PR DESCRIPTION
This allows third party developers to reuse most
of the theme variables and only modify the variables
they want to change when instantiating a theme.