### PR TITLE
Use Promises  for RefreshControl

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -132,7 +132,16 @@ class ListView extends React.Component {
     });
 
     if (this.props.onRefresh) {
-      this.props.onRefresh();
+      const callback = this.props.onRefresh();
+      const setIdle = () => {
+        this.setState({
+          status: Status.IDLE,
+        });
+      };
+
+      if(typeof callback === 'object' && typeof callback.then === 'function') {
+        callback.then(setIdle, setIdle);
+      }
     }
   }
 


### PR DESCRIPTION
I faced with an issue that in `ListView` _RefreshControl_ spins forever...
Someone recommend to use ListView loading prop to Dismiss refreshControl, but it seems in ListView Statuses are strings like `Status.IDLE`, `Status.REFRESHING` and so on, but the loading prop is a boolean value and it cause issues.

Currently refresh Control automatically set _ListView Component_ `status: Status.REFRESHING` and then call `this.props.onRefresh` that I was passed from MyComponent.
In MyComponent I have an state like `this.state.loading : false` and when I want to set `loading` prop, I should set it to `this.setState({loading: true})` on MyComponent `onRefresh` prop, so as soon as ListView `componentWillReceiveProps` triggered, refreshControl will disappear ( in Less than one second ), _because my status state is not equals to ListView component status state_. So there is no possibility to keep spins without hacks.

so Its nice to use Promise to handle this issue.
```
<ListView
    data={this.state.items}
    loading={this.state.loading}
    onRefresh={() => {
       return new Promise((resolve, reject) => {
           setTimeout(() => {
               resolve(true);
           }, 4000);
       });
    }}
    renderRow={() => {}}
/>
```