### PR TITLE
Add missing padding to NavigationBar container

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -1287,6 +1287,8 @@ export default (variables = defaultThemeVariables) => ({
       borderBottomWidth: 1,
       // Leave space for the status bar on iOS
       paddingTop: Platform.OS === 'ios' ? 20 : 0,
+      paddingLeft: 15,
+      paddingRight: 15,
     },
 
     componentsContainer: {


### PR DESCRIPTION
[This changes](https://github.com/shoutem/ui/pull/216/files) fixed the vertical alignment but removed the padding so the icons on the Navbar didn't have any spacing to the sides.