### PR TITLE
Fix for horizontal pager

### DIFF
--- a/components/HorizontalPager/HorizontalPager.js
+++ b/components/HorizontalPager/HorizontalPager.js
@@ -239,6 +239,9 @@ class HorizontalPager extends Component {
         pageWidth = width - pageMargin - style.nextPageInsetSize;
       }
 
+      // Fixes where multiple pages appear at once on initial load (if surroundingPagesToLoad > 0)
+      if (!containerWidth) return null;
+
       const isPageActive = (selectedIndex === pageIndex);
       const pageContent = this.shouldRenderPage(pageIndex) && (
         <Page


### PR DESCRIPTION
Fixes issue that shows multiple screens at once on initial load if surroundingPagesToLoad is greater than 0

https://github.com/shoutem/ui/issues/297