### PR TITLE
README.md, CRNA package.json and Videos.js example fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To see how Shoutem UI works, you can:
 ### Examples component
 
 **If you are using Expo, see [this
-project](https://github.com/exponentjs/shoutem-example/blob/master/main.js)
+project](https://github.com/shoutem/ui/blob/develop/examples/create-react-native-app/App.js)
 for example usage. Otherwise, follow the steps below.**
 
 Create new React Native project and locate to it:

--- a/examples/components/Videos.js
+++ b/examples/components/Videos.js
@@ -11,7 +11,7 @@ export function Videos() {
     <View styleName="vertical collapsed">
       <Stage title={"YouTube video"}>
         <Video
-          source={{uri: "https://www.youtube.com/embed/GCSeAiScMfg"}}
+          source={{uri: "https://www.youtube.com/embed/2zuisMXzyaI"}}
           width={320}
           height={180}
         />
@@ -25,7 +25,7 @@ export function Videos() {
       </Stage>
       <Stage title={"Stream video"}>
         <Video
-          source={{uri: "https://archive.org/download/WebmVp8Vorbis/webmvp8_512kb.mp4"}}
+          source={{uri: "https://archive.org/download/Sintel/sintel-2048-stereo_512kb.mp4"}}
           width={320}
           height={180}
         />

--- a/examples/create-react-native-app/package.json
+++ b/examples/create-react-native-app/package.json
@@ -22,6 +22,6 @@
     "@shoutem/ui": "0.22.0",
     "expo": "^23.0.4",
     "react": "16.0.0",
-    "react-native": "0.50.3",
+    "react-native": "0.50.3"
   }
 }


### PR DESCRIPTION
Changed link in `README.md` that pointed to outdated Expo example of Shoutem UI.

Fixed `create-react-native-app` example app `package.json` file.

Fixed broken `Videos.js` example component links.