### PR TITLE
ViewPropTypes update

### DIFF
--- a/components/GridRow.js
+++ b/components/GridRow.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Children } from 'react';
 import {
   View as RNView,
-  ViewPropTypes as RNViewPropTypes,
+  ViewPropTypes,
 } from 'react-native';
 import _ from 'lodash';
 
@@ -40,7 +40,7 @@ class GridRow extends React.Component {
 
 GridRow.propTypes = {
   columns: PropTypes.number.isRequired,
-  ...RNViewPropTypes,
+  ...ViewPropTypes,
 };
 
 /* eslint-disable no-param-reassign */

--- a/components/GridRow.js
+++ b/components/GridRow.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { Children } from 'react';
-import { View as RNView } from 'react-native';
+import {
+  View as RNView,
+  ViewPropTypes as RNViewPropTypes,
+} from 'react-native';
 import _ from 'lodash';
 
 import { View } from './View';
@@ -37,7 +40,7 @@ class GridRow extends React.Component {
 
 GridRow.propTypes = {
   columns: PropTypes.number.isRequired,
-  ...RNView.propTypes,
+  ...RNViewPropTypes,
 };
 
 /* eslint-disable no-param-reassign */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.0",
@@ -17,7 +17,7 @@
     "react-native-transformable-image": "shoutem/react-native-transformable-image#v0.0.20",
     "react-native-vector-icons": "~4.3.0",
     "react-native-photo-view": "~1.5.0",
-    "react-native-navigation-experimental-compat": "1.1.0",
+    "react-native-navigation-experimental-compat": "goshakkk/react-native-navigation-experimental-compat#fbce4b9e478f808634a98dac48901ec6ed4ee9fd",
     "stream": "0.0.2",
     "tinycolor2": "~1.3.0",
     "prop-types": "^15.5.10"


### PR DESCRIPTION
Replaced `View.propTypes` with `ViewPropTypes` imported from `react-native`.

Updated `react-native-navigation-experimental-compat` dependency.