### PR TITLE
Update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.0",
@@ -10,7 +10,7 @@
     "events": "1.1.0",
     "html-entities": "~1.2.0",
     "htmlparser2": "~3.9.0",
-    "lodash": "~4.15.0",
+    "lodash": "~4.17.4",
     "qs": "~4.0.0",
     "react-native-lightbox": "shoutem/react-native-lightbox#v0.7.1",
     "react-native-linear-gradient": "~2.2.0",


### PR DESCRIPTION
Updated `lodash` from 4.15.0 to 4.17.4 for Shoutem platform needs.

Bumped to version 0.22.3.