### PR TITLE
Version bump due to NPM issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.0",


### PR DESCRIPTION
NPM ignores unpublish for beta-published 0.23.3 version, cannot proceed with release unless 0.23.4+ is set.