### PR TITLE
allow render html override

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -55,9 +55,9 @@ class SimpleHtml extends PureComponent {
     const paddingValue = style.container.paddingLeft * 2;
     const maxWidth = Dimensions.get('window').width - paddingValue;
     const nodeHeight = _.get(node, 'attribus.height');
-    const nodeRatio = nodeWidth/nodeHeight;
+    const nodeRatio = nodeWidth / nodeHeight;
     const resolvedWidth = (nodeWidth > maxWidth) ? maxWidth : nodeWidth;
-    const resolvedHeight =  Math.round(resolvedWidth*nodeRatio);
+    const resolvedHeight = Math.round(resolvedWidth * nodeRatio);
 
     const nodeStyle = cssStringToObject(styleAttrib);
     const invalidKeys = getEmptyObjectKeys(nodeStyle);
@@ -91,7 +91,7 @@ class SimpleHtml extends PureComponent {
   }
 
   render() {
-    const { style, body, customTagStyles } = this.props;
+    const { style, body, customTagStyles, ...otherProps } = this.props;
 
     const paddingValue = style.container.paddingLeft * 2;
     const maxWidth = Dimensions.get('window').width - paddingValue;
@@ -119,7 +119,7 @@ class SimpleHtml extends PureComponent {
 
     return (
       <View style={style.container}>
-        <HTML {...htmlProps} />
+        <HTML {...htmlProps} {...otherProps} />
       </View>
     );
   }


### PR DESCRIPTION
Since this component styling is a little tricky, this PR allows for specific case overrides for any of the react-native-render-html props. 

In our case, we'd like to modify `[baseFontStyle](https://github.com/archriss/react-native-render-html#styling)` prop per case basis, as we do not have a general style in place.