### PR TITLE
Add scrollIndicatorInsets to ListView component

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -144,6 +144,10 @@ class ListView extends Component {
     // style
     mappedProps.style = style.list;
     mappedProps.contentContainerStyle = style.listContent;
+    
+    if ((Platform.OS === 'ios') && (parseInt(Platform.Version, 10) === 13)) {
+      mappedProps.scrollIndicatorInsets={ right: 1 };
+    }
 
     // rendering
     mappedProps.ListHeaderComponent = this.createListHeaderComponent(renderHeader, autoHideHeader);


### PR DESCRIPTION
Added scrollIndicatorInsets to ListView component. It forces  scrollbar to be rendered correctly:  
https://github.com/facebook/react-native/issues/26610#issuecomment-539843444

I've applyed the fix for iOS 13 only

This was my initial PR: https://github.com/shoutem/mobile/pull/94 