### PR TITLE
Adjust react-native-vector-icons semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",
@@ -22,7 +22,7 @@
     "react-native-photo-view": "shoutem/react-native-photo-view#0ffa1481f6b6cb8663cb291b7db1d6644440584d",
     "react-native-render-html": "~4.2.0",
     "react-native-transformable-image": "shoutem/react-native-transformable-image#v0.0.20",
-    "react-native-vector-icons": "^6.6.0",
+    "react-native-vector-icons": "~6.6.0",
     "react-native-webview": "9.4.0",
     "stream": "0.0.2",
     "tinycolor2": "1.4.1"


### PR DESCRIPTION
Adjusts semver for `react-native-vector-icons` package, in order to not avoid using the version with Shoutem platform incompatible dependency.