### PR TITLE
Make fs-extra dependency semver in line with Shoutem build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",
@@ -9,7 +9,7 @@
     "babel-plugin-transform-decorators-legacy": "~1.3.4",
     "buffer": "5.6.0",
     "events": "1.1.0",
-    "fs-extra": "9.0.0",
+    "fs-extra": "^7.0.1",
     "html-entities": "1.3.1",
     "htmlparser2": "3.10.1",
     "lodash": "4.17.15",


### PR DESCRIPTION
`fs-extra` has a bug in `9.0.0` which causes issues with our automated build system. Changing this dependency effectively has no change on our end, but allows us to use `fs-extra` for the minimal use we have within this package.