### PR TITLE
Feature/seext 8053 investigate line height ratio implementation change

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,19 @@
 import { setDefaultThemeStyle } from './init';
-import getTheme, { defaultThemeVariables, dimensionRelativeToIphone } from './theme';
+import getTheme, {
+  defaultThemeVariables,
+  dimensionRelativeToIphone,
+  calculateLineHeight,
+} from "./theme";
 
 setDefaultThemeStyle();
 
 // Theme
-export { getTheme, defaultThemeVariables, dimensionRelativeToIphone };
+export {
+  getTheme,
+  defaultThemeVariables,
+  dimensionRelativeToIphone,
+  calculateLineHeight,
+};
 
 // Components
 export { ActionSheet } from './components/ActionSheet';

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import getTheme, {
   defaultThemeVariables,
   dimensionRelativeToIphone,
   calculateLineHeight,
-} from "./theme";
+} from './theme';
 
 setDefaultThemeStyle();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",

--- a/theme.js
+++ b/theme.js
@@ -52,11 +52,15 @@ export function dimensionRelativeToIphone(dimension, actualRefVal = window.width
   return getSizeRelativeToReference(dimension, 375, actualRefVal);
 }
 
-// This function is depricated and replaced with calculateLineHeight. 
+// This function is deprecated and replaced with calculateLineHeight. 
 // It remains present here because of the backward compatibility. 
 export function formatLineHeight(fontSize) {
   // adds required padding to lineHeight to support
   // different alphabets (Kanji, Greek, etc.)
+
+  console.warn(
+    "formatLineHeight is deprecated and will be removed. Please use calculateLineHeight instead, it can simply be renamed as it takes the same argument and returns the same expected value, but more consistently across all fontSize."
+  );
 
   if (fontSize < 22) {
     // minimum lineHeight for different alphabets is 25

--- a/theme.js
+++ b/theme.js
@@ -52,6 +52,8 @@ export function dimensionRelativeToIphone(dimension, actualRefVal = window.width
   return getSizeRelativeToReference(dimension, 375, actualRefVal);
 }
 
+// This function is depricated and replaced with calculateLineHeight. 
+// It remains present here because of the backward compatibility. 
 export function formatLineHeight(fontSize) {
   // adds required padding to lineHeight to support
   // different alphabets (Kanji, Greek, etc.)
@@ -62,6 +64,10 @@ export function formatLineHeight(fontSize) {
   }
 
   return (fontSize + 3);
+}
+
+export function calculateLineHeight(fontSize) {
+  return (fontSize * 1.5);
 }
 
 export const defaultThemeVariables = {


### PR DESCRIPTION
I've added one dummy function that calculates lineHeight. After reading multiple blogs on the subject, I've tested and verified theory that lineHeight should be 1.5 em. 

So, if the fontSize is 16px, our calculation is 16*1.5=24px. Minimal lineHeight is 24px which means it'll add 4 pixels under the text and above it. This way we cover multiple languanges and diacritic marks. 