### PR TITLE
Release/3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -896,6 +896,13 @@
       "requires": {
         "hoist-non-react-statics": "^3.3.2",
         "lodash": "4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "@shoutem/theme": {
@@ -1817,9 +1824,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -2223,22 +2230,24 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-native-gesture-responder": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-responder/-/react-native-gesture-responder-0.1.1.tgz",
-      "integrity": "sha1-gCVS2OtxU8DYGjlumPS4C0BLZ5g=",
-      "requires": {
-        "react-timer-mixin": "^0.13.3"
-      }
-    },
     "react-native-lightbox": {
       "version": "github:shoutem/react-native-lightbox#91f3f58759e9901d9c006b01ce32d074606eda0e",
       "from": "github:shoutem/react-native-lightbox#v0.7.2",
       "requires": {
         "create-react-class": "^15.6.2",
         "prop-types": "^15.5.10",
-        "react-native-view-transformer": "github:shoutem/react-native-view-transformer#8dff34405f9b443ae5effa3660eefccbc35049ed",
         "react-timer-mixin": "^0.13.3"
+      },
+      "dependencies": {
+        "react-native-view-transformer": {
+          "version": "github:shoutem/react-native-view-transformer#8dff34405f9b443ae5effa3660eefccbc35049ed",
+          "from": "github:shoutem/react-native-view-transformer#8dff34405f9b443ae5effa3660eefccbc35049ed",
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react-native-gesture-responder": "0.1.1",
+            "react-native-scroller": "0.0.6"
+          }
+        }
       }
     },
     "react-native-linear-gradient": {
@@ -2294,11 +2303,6 @@
         }
       }
     },
-    "react-native-scroller": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/react-native-scroller/-/react-native-scroller-0.0.6.tgz",
-      "integrity": "sha1-3qjIm9HKLSRF+7azqQlg32wXZ/8="
-    },
     "react-native-status-bar-height": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-native-status-bar-height/-/react-native-status-bar-height-2.5.0.tgz",
@@ -2308,8 +2312,18 @@
       "version": "github:shoutem/react-native-transformable-image#ef2e93fa9425bbb479bccec64d165ec85e76e949",
       "from": "github:shoutem/react-native-transformable-image#v0.0.20",
       "requires": {
-        "prop-types": "^15.5.10",
-        "react-native-view-transformer": "github:shoutem/react-native-view-transformer#8dff34405f9b443ae5effa3660eefccbc35049ed"
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "react-native-view-transformer": {
+          "version": "github:shoutem/react-native-view-transformer#8dff34405f9b443ae5effa3660eefccbc35049ed",
+          "from": "github:shoutem/react-native-view-transformer#8dff34405f9b443ae5effa3660eefccbc35049ed",
+          "requires": {
+            "prop-types": "^15.5.10",
+            "react-native-gesture-responder": "0.1.1",
+            "react-native-scroller": "0.0.6"
+          }
+        }
       }
     },
     "react-native-vector-icons": {
@@ -2320,15 +2334,6 @@
         "lodash": "^4.0.0",
         "prop-types": "^15.6.2",
         "yargs": "^13.2.2"
-      }
-    },
-    "react-native-view-transformer": {
-      "version": "github:shoutem/react-native-view-transformer#8dff34405f9b443ae5effa3660eefccbc35049ed",
-      "from": "github:shoutem/react-native-view-transformer#v0.0.29",
-      "requires": {
-        "prop-types": "^15.5.10",
-        "react-native-gesture-responder": "0.1.1",
-        "react-native-scroller": "0.0.6"
       }
     },
     "react-native-webview": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fs-extra": "^7.0.1",
     "html-entities": "1.3.1",
     "htmlparser2": "3.10.1",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "prop-types": "^15.7.2",
     "qs": "6.9.3",
     "react-native-lightbox": "shoutem/react-native-lightbox#v0.7.2",


### PR DESCRIPTION
- removes `react` and `react-native` from `dependencies` and updates their entries under `peerDependencies` to minimum versions
- update `package-lock.json`
- bumps to 3.0.0 as this can be considered a breaking change
- bumps `lodash` to dependabot suggestion

Merging without review as all changes have already been approved previously.