### PR TITLE
Bump version and add react-native-svg to nativeDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",
@@ -47,6 +47,7 @@
   "nativeDependencies": [
     "react-native-linear-gradient",
     "react-native-photo-view",
+    "react-native-svg",
     "react-native-vector-icons",
     "react-native-webview"
   ],


### PR DESCRIPTION
Jira issue for Shoutem devs:
[react-native-svg not autolinked by @shoutem/ui SEEXT-8505](https://fiveminutes.jira.com/browse/SEEXT-8505)

Add `react-native-svg` to `nativeDependencies` in order to support it's autolinking when not provided in root `package.json` otherwise.