### PR TITLE
Feature/seext 8410 rss photos details screen title cut off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",

--- a/theme.js
+++ b/theme.js
@@ -2373,7 +2373,7 @@ export default (variables = defaultThemeVariables) => ({
           paddingTop:
             NAVIGATION_BAR_HEIGHT +
             (Platform.OS === "ios"
-              ? variables.extraLargeGutter + variables.mediumGutter
+              ? variables.extraLargeGutter + variables.extraLargeGutter
               : variables.mediumGutter),
         },
       },

--- a/theme.js
+++ b/theme.js
@@ -2370,7 +2370,11 @@ export default (variables = defaultThemeVariables) => ({
           // visible underneath the navigation bar, but the
           // title text should be rendered below the
           // navigation bar.
-          paddingTop: NAVIGATION_BAR_HEIGHT + variables.mediumGutter,
+          paddingTop:
+            NAVIGATION_BAR_HEIGHT +
+            (Platform.OS === "ios"
+              ? variables.extraLargeGutter + variables.mediumGutter
+              : variables.mediumGutter),
         },
       },
     },


### PR DESCRIPTION
Added padding to ImageGalleryOverview's title for iOS devices.
Android already had this title under the image counter. Did the same for iOS devices.
Now, if the title is 2 rows long, it won't go over the image counter.

Note: image counter is barely visible because it gains color from the navigation title color setting, so it's the same color as the ImageGallery component background.

Before:
![image](https://user-images.githubusercontent.com/57353746/94424655-dd9b7700-018a-11eb-8648-9cb569004f4d.png)

After:
![IMG_0061](https://user-images.githubusercontent.com/57353746/94791087-758da080-03d7-11eb-9737-7527d6a63ee3.jpg)
![IMG_1406](https://user-images.githubusercontent.com/57353746/94791092-77effa80-03d7-11eb-9a80-00c19996e8da.jpg)
![IMG_1407](https://user-images.githubusercontent.com/57353746/94791097-78889100-03d7-11eb-8b2f-7c199b8792d8.jpg)

