### PR TITLE
Feature/android fontfamily resolving

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ export {
   dimensionRelativeToIphone,
   calculateLineHeight,
   resolveFontFamily,
+  resolveFontWeight,
+  resolveFontStyle,
 };
 
 // Components

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import getTheme, {
   defaultThemeVariables,
   dimensionRelativeToIphone,
   calculateLineHeight,
+  resolveFontFamily,
 } from './theme';
 
 setDefaultThemeStyle();
@@ -13,6 +14,7 @@ export {
   defaultThemeVariables,
   dimensionRelativeToIphone,
   calculateLineHeight,
+  resolveFontFamily,
 };
 
 // Components

--- a/theme.js
+++ b/theme.js
@@ -52,8 +52,35 @@ export function dimensionRelativeToIphone(dimension, actualRefVal = window.width
   return getSizeRelativeToReference(dimension, 375, actualRefVal);
 }
 
-// This function is deprecated and replaced with calculateLineHeight. 
-// It remains present here because of the backward compatibility. 
+// 'fontWeight' and 'fontStyle' aren't always supplied for every component, so we're setting default
+// values of 'normal'.
+export function resolveFontFamily(fontName, fontWeight = 'normal', fontStyle = 'normal') {
+  if (Platform.OS === 'ios') {
+    return fontName;
+  }
+
+  // Currently, Android text will only be bolded for fontWeight 700. Every other (even higher) value
+  // will return the default, un-bolded text.
+  const isBold = fontWeight >= 700 || fontWeight === 'bold';
+  const isItalic = fontStyle === 'italic';
+
+  if (isBold && isItalic) {
+    return `${fontName}-BoldItalic`;
+  }
+
+  if (isBold) {
+    return `${fontName}-Bold`;
+  }
+
+  if (isItalic) {
+    return `${fontName}-Italic`;
+  }
+
+  return `${fontName}-Regular`;
+}
+
+// This function is deprecated and replaced with calculateLineHeight.
+// It remains present here because of the backward compatibility.
 export function formatLineHeight(fontSize) {
   // adds required padding to lineHeight to support
   // different alphabets (Kanji, Greek, etc.)
@@ -376,6 +403,11 @@ export default (variables = defaultThemeVariables) => ({
 
     lineHeight: formatLineHeight(variables.heading.fontSize),
     ...variables.heading,
+    fontFamily: resolveFontFamily(
+      variables.heading.fontFamily,
+      variables.heading.fontWeight,
+      variables.heading.fontStyle,
+    ),
   },
 
   'shoutem.ui.Title': {
@@ -383,13 +415,23 @@ export default (variables = defaultThemeVariables) => ({
 
     lineHeight: formatLineHeight(variables.title.fontSize),
     ...variables.title,
+    fontFamily: resolveFontFamily(
+      variables.title.fontFamily,
+      variables.title.fontWeight,
+      variables.title.fontStyle,
+    ),
   },
 
   'shoutem.ui.Subtitle': {
     [INCLUDE]: ['text'],
 
-    lineHeight: formatLineHeight(variables.subtitle.fontSize),
+    lineHeight: formatLineHeight(variables.title.fontSize),
     ...variables.subtitle,
+    fontFamily: resolveFontFamily(
+      variables.subtitle.fontFamily,
+      variables.subtitle.fontWeight,
+      variables.subtitle.fontStyle,
+    ),
   },
 
   'shoutem.ui.Caption': {
@@ -398,12 +440,22 @@ export default (variables = defaultThemeVariables) => ({
     lineHeight: formatLineHeight(variables.caption.fontSize),
     letterSpacing: 0.5,
     ...variables.caption,
+    fontFamily: resolveFontFamily(
+      variables.caption.fontFamily,
+      variables.caption.fontWeight,
+      variables.caption.fontStyle,
+    ),
   },
 
   'shoutem.ui.Text': {
     [INCLUDE]: ['text'],
 
     ...variables.text,
+    fontFamily: resolveFontFamily(
+      variables.text.fontFamily,
+      variables.text.fontWeight,
+      variables.text.fontStyle,
+    ),
   },
 
   //
@@ -1038,6 +1090,11 @@ export default (variables = defaultThemeVariables) => ({
     'shoutem.ui.Text': {
       // Inherit color
       ...variables.text,
+      fontFamily: resolveFontFamily(
+        variables.text.fontFamily,
+        variables.text.fontWeight,
+        variables.text.fontStyle,
+      ),
     },
 
     'shoutem.ui.Icon': {
@@ -1132,6 +1189,11 @@ export default (variables = defaultThemeVariables) => ({
 
     'shoutem.ui.Text': {
       ...variables.primaryButtonText,
+      fontFamily: resolveFontFamily(
+        variables.text.fontFamily,
+        variables.text.fontWeight,
+        variables.text.fontStyle,
+      ),
       letterSpacing: 1,
       marginVertical: 12,
       marginRight: 10,
@@ -1321,6 +1383,11 @@ export default (variables = defaultThemeVariables) => ({
       },
 
       ...createSharedStyle(['shoutem.ui.Title', 'shoutem.ui.Icon', 'shoutem.ui.Text'], {
+        fontFamily: resolveFontFamily(
+          variables.title.fontFamily,
+          variables.title.fontWeight,
+          variables.title.fontStyle,
+        ),
         color: variables.featuredNavBarTitleColor,
       }),
 
@@ -1347,6 +1414,11 @@ export default (variables = defaultThemeVariables) => ({
     'shoutem.ui.Text': {
       [INCLUDE]: ['navigationBarTextAnimations'],
       ...variables.navBarText,
+      fontFamily: resolveFontFamily(
+        variables.navBarText.fontFamily,
+        variables.navBarText.fontWeight,
+        variables.navBarText.fontStyle,
+      ),
       paddingHorizontal: 9,
     },
 
@@ -1360,6 +1432,11 @@ export default (variables = defaultThemeVariables) => ({
       'shoutem.ui.Text': {
         [INCLUDE]: ['navigationBarTextAnimations'],
         ...variables.navBarText,
+        fontFamily: resolveFontFamily(
+          variables.navBarText.fontFamily,
+          variables.navBarText.fontWeight,
+          variables.navBarText.fontStyle,
+        ),
         fontWeight: 'normal',
         color: variables.navBarIconsColor,
         letterSpacing: 0,
@@ -1380,6 +1457,11 @@ export default (variables = defaultThemeVariables) => ({
         },
         'shoutem.ui.Text': {
           ...variables.navBarText,
+          fontFamily: resolveFontFamily(
+            variables.navBarText.fontFamily,
+            variables.navBarText.fontWeight,
+            variables.navBarText.fontStyle,
+          ),
           fontWeight: 'normal',
           color: variables.navBarIconsColor,
         },
@@ -1445,6 +1527,11 @@ export default (variables = defaultThemeVariables) => ({
       color: variables.navBarText.color,
       lineHeight: formatLineHeight(variables.navBarText.fontSize),
       ...variables.navBarText,
+      fontFamily: resolveFontFamily(
+        variables.navBarText.fontFamily,
+        variables.navBarText.fontWeight,
+        variables.navBarText.fontStyle,
+      ),
     },
 
     statusBar: {
@@ -1581,6 +1668,11 @@ export default (variables = defaultThemeVariables) => ({
       textAlign: 'center',
       lineHeight: formatLineHeight(variables.navBarText.fontSize),
       ...variables.navBarText,
+      fontFamily: resolveFontFamily(
+        variables.navBarText.fontFamily,
+        variables.navBarText.fontWeight,
+        variables.navBarText.fontStyle,
+      ),
     },
 
     container: {
@@ -1781,6 +1873,11 @@ export default (variables = defaultThemeVariables) => ({
     paddingVertical: 18,
     underlineColorAndroid: 'transparent',
     ...variables.text,
+    fontFamily: resolveFontFamily(
+      variables.text.fontFamily,
+      variables.text.fontWeight,
+      variables.text.fontStyle,
+    ),
   },
 
   'shoutem.ui.NumberInput': {
@@ -1903,6 +2000,11 @@ export default (variables = defaultThemeVariables) => ({
         },
         'shoutem.ui.Text': {
           ...variables.navBarText,
+          fontFamily: resolveFontFamily(
+            variables.navBarText.fontFamily,
+            variables.navBarText.fontWeight,
+            variables.navBarText.fontStyle,
+          ),
           color: variables.text.color,
           fontWeight: 'normal',
           textAlign: 'center',
@@ -2006,6 +2108,11 @@ export default (variables = defaultThemeVariables) => ({
         paddingVertical: 23,
         alignSelf: 'stretch',
         ...variables.subtitle,
+        fontFamily: resolveFontFamily(
+          variables.subtitle.fontFamily,
+          variables.subtitle.fontWeight,
+          variables.subtitle.fontStyle,
+        ),
       },
     },
     selectedModalItem: {
@@ -2017,6 +2124,11 @@ export default (variables = defaultThemeVariables) => ({
         paddingVertical: 23,
         alignSelf: 'stretch',
         ...variables.subtitle,
+        fontFamily: resolveFontFamily(
+          variables.subtitle.fontFamily,
+          variables.subtitle.fontWeight,
+          variables.subtitle.fontStyle,
+        ),
         fontWeight: '500'
       },
     },

--- a/theme.js
+++ b/theme.js
@@ -59,24 +59,27 @@ export function resolveFontFamily(fontName, fontWeight = 'normal', fontStyle = '
     return fontName;
   }
 
+  // If we receive the fontName as Rubik-Regular, we should only use Rubik.
+  const resolvedFontName = fontName.split('-')[0];
+
   // Currently, Android text will only be bolded for fontWeight 700. Every other (even higher) value
   // will return the default, un-bolded text.
-  const isBold = fontWeight >= 700 || fontWeight === 'bold';
+  const isBold = parseInt(fontWeight) >= 700 || fontWeight === 'bold';
   const isItalic = fontStyle === 'italic';
 
   if (isBold && isItalic) {
-    return `${fontName}-BoldItalic`;
+    return `${resolvedFontName}-BoldItalic`;
   }
 
   if (isBold) {
-    return `${fontName}-Bold`;
+    return `${resolvedFontName}-Bold`;
   }
 
   if (isItalic) {
-    return `${fontName}-Italic`;
+    return `${resolvedFontName}-Italic`;
   }
 
-  return `${fontName}-Regular`;
+  return `${resolvedFontName}-Regular`;
 }
 
 // This function is deprecated and replaced with calculateLineHeight.
@@ -408,6 +411,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.heading.fontWeight,
       variables.heading.fontStyle,
     ),
+    fontWeight: Platform.OS === 'ios' ? variables.heading.fontWeight : 'normal',
+    fontStyle: Platform.OS === 'ios' ? variables.heading.fontStyle : 'normal',
   },
 
   'shoutem.ui.Title': {
@@ -420,6 +425,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.title.fontWeight,
       variables.title.fontStyle,
     ),
+    fontWeight: Platform.OS === 'ios' ? variables.title.fontWeight : 'normal',
+    fontStyle: Platform.OS === 'ios' ? variables.title.fontStyle : 'normal',
   },
 
   'shoutem.ui.Subtitle': {
@@ -432,6 +439,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.subtitle.fontWeight,
       variables.subtitle.fontStyle,
     ),
+    fontWeight: Platform.OS === 'ios' ? variables.subtitle.fontWeight : 'normal',
+    fontStyle: Platform.OS === 'ios' ? variables.subtitle.fontStyle : 'normal',
   },
 
   'shoutem.ui.Caption': {
@@ -445,6 +454,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.caption.fontWeight,
       variables.caption.fontStyle,
     ),
+    fontWeight: Platform.OS === 'ios' ? variables.caption.fontWeight : 'normal',
+    fontStyle: Platform.OS === 'ios' ? variables.caption.fontStyle : 'normal',
   },
 
   'shoutem.ui.Text': {
@@ -456,6 +467,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.text.fontWeight,
       variables.text.fontStyle,
     ),
+    fontWeight: Platform.OS === 'ios' ? variables.text.fontWeight : 'normal',
+    fontStyle: Platform.OS === 'ios' ? variables.text.fontStyle : 'normal',
   },
 
   //
@@ -1095,6 +1108,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.text.fontWeight,
         variables.text.fontStyle,
       ),
+      fontWeight: Platform.OS === 'ios' ? variables.text.fontWeight : 'normal',
+      fontStyle: Platform.OS === 'ios' ? variables.text.fontStyle : 'normal',
     },
 
     'shoutem.ui.Icon': {
@@ -1190,10 +1205,12 @@ export default (variables = defaultThemeVariables) => ({
     'shoutem.ui.Text': {
       ...variables.primaryButtonText,
       fontFamily: resolveFontFamily(
-        variables.text.fontFamily,
-        variables.text.fontWeight,
-        variables.text.fontStyle,
+        variables.primaryButtonText.fontFamily,
+        variables.primaryButtonText.fontWeight,
+        variables.primaryButtonText.fontStyle,
       ),
+      fontWeight: Platform.OS === 'ios' ? variables.primaryButtonText.fontWeight : 'normal',
+      fontStyle: Platform.OS === 'ios' ? variables.primaryButtonText.fontStyle : 'normal',
       letterSpacing: 1,
       marginVertical: 12,
       marginRight: 10,
@@ -1388,6 +1405,8 @@ export default (variables = defaultThemeVariables) => ({
           variables.title.fontWeight,
           variables.title.fontStyle,
         ),
+        fontWeight: Platform.OS === 'ios' ? variables.title.fontWeight : 'normal',
+        fontStyle: Platform.OS === 'ios' ? variables.title.fontStyle : 'normal',
         color: variables.featuredNavBarTitleColor,
       }),
 
@@ -1419,6 +1438,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.navBarText.fontWeight,
         variables.navBarText.fontStyle,
       ),
+      fontWeight: Platform.OS === 'ios' ? variables.navBarText.fontWeight : 'normal',
+      fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
       paddingHorizontal: 9,
     },
 
@@ -1438,6 +1459,7 @@ export default (variables = defaultThemeVariables) => ({
           variables.navBarText.fontStyle,
         ),
         fontWeight: 'normal',
+        fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
         color: variables.navBarIconsColor,
         letterSpacing: 0,
       },
@@ -1459,10 +1481,11 @@ export default (variables = defaultThemeVariables) => ({
           ...variables.navBarText,
           fontFamily: resolveFontFamily(
             variables.navBarText.fontFamily,
-            'normal'
+            'normal',
             variables.navBarText.fontStyle,
           ),
           fontWeight: 'normal',
+          fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
           color: variables.navBarIconsColor,
         },
       },
@@ -1532,6 +1555,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.navBarText.fontWeight,
         variables.navBarText.fontStyle,
       ),
+      fontWeight: Platform.OS === 'ios' ? variables.navBarText.fontWeight : 'normal',
+      fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
     },
 
     statusBar: {
@@ -1673,6 +1698,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.navBarText.fontWeight,
         variables.navBarText.fontStyle,
       ),
+      fontWeight: Platform.OS === 'ios' ? variables.navBarText.fontWeight : 'normal',
+      fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
     },
 
     container: {
@@ -1878,6 +1905,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.text.fontWeight,
       variables.text.fontStyle,
     ),
+    fontWeight: Platform.OS === 'ios' ? variables.text.fontWeight : 'normal',
+    fontStyle: Platform.OS === 'ios' ? variables.text.fontStyle : 'normal',
   },
 
   'shoutem.ui.NumberInput': {
@@ -2007,6 +2036,7 @@ export default (variables = defaultThemeVariables) => ({
           ),
           color: variables.text.color,
           fontWeight: 'normal',
+          fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
           textAlign: 'center',
         },
       },
@@ -2113,6 +2143,8 @@ export default (variables = defaultThemeVariables) => ({
           variables.subtitle.fontWeight,
           variables.subtitle.fontStyle,
         ),
+        fontWeight: Platform.OS === 'ios' ? variables.subtitle.fontWeight : 'normal',
+        fontStyle: Platform.OS === 'ios' ? variables.subtitle.fontStyle : 'normal',
       },
     },
     selectedModalItem: {
@@ -2129,7 +2161,8 @@ export default (variables = defaultThemeVariables) => ({
           '500',
           variables.subtitle.fontStyle,
         ),
-        fontWeight: '500'
+        fontWeight: Platform.OS === 'ios' ? '500' : 'normal',
+        fontStyle: Platform.OS === 'ios' ? variables.subtitle.fontStyle : 'normal',
       },
     },
 

--- a/theme.js
+++ b/theme.js
@@ -82,6 +82,28 @@ export function resolveFontFamily(fontName, fontWeight = 'normal', fontStyle = '
   return `${resolvedFontName}-Regular`;
 }
 
+// Currently, resolveFontFamily will provide fontWeight styling, but any value other than 'normal'
+// being provided to fontWeight will cause the default system font to be used, so we conditionally
+// resolve it.
+export function resolveFontWeight(fontWeight) {
+  if (Platform.OS === 'ios') {
+    return fontWeight;
+  }
+
+  return 'normal';
+}
+
+// Currently, resolveFontFamily will provide fontStyle styling, but any value other than 'normal'
+// being provided to fontStyle will cause the default system font to be used, so we conditionally
+// resolve it.
+export function resolveFontWeight(fontStyle) {
+  if (Platform.OS === 'ios') {
+    return fontStyle;
+  }
+
+  return 'normal';
+}
+
 // This function is deprecated and replaced with calculateLineHeight.
 // It remains present here because of the backward compatibility.
 export function formatLineHeight(fontSize) {
@@ -344,11 +366,11 @@ export default (variables = defaultThemeVariables) => ({
   },
 
   boldTextStyle: {
-    fontWeight: '500',
+    fontWeight: resolveFontWeight('500'),
   },
 
   italicTextStyle: {
-    fontStyle: 'italic',
+    fontStyle: resolveFontStyle('italic'),
   },
 
   codeTextStyle: {
@@ -411,8 +433,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.heading.fontWeight,
       variables.heading.fontStyle,
     ),
-    fontWeight: Platform.OS === 'ios' ? variables.heading.fontWeight : 'normal',
-    fontStyle: Platform.OS === 'ios' ? variables.heading.fontStyle : 'normal',
+    fontWeight: resolveFontWeight(variables.heading.fontWeight),
+    fontStyle: resolveFontStyle(variables.heading.fontStyle),
   },
 
   'shoutem.ui.Title': {
@@ -425,8 +447,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.title.fontWeight,
       variables.title.fontStyle,
     ),
-    fontWeight: Platform.OS === 'ios' ? variables.title.fontWeight : 'normal',
-    fontStyle: Platform.OS === 'ios' ? variables.title.fontStyle : 'normal',
+    fontWeight: resolveFontWeight(variables.title.fontWeight),
+    fontStyle: resolveFontStyle(variables.title.fontStyle),
   },
 
   'shoutem.ui.Subtitle': {
@@ -439,8 +461,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.subtitle.fontWeight,
       variables.subtitle.fontStyle,
     ),
-    fontWeight: Platform.OS === 'ios' ? variables.subtitle.fontWeight : 'normal',
-    fontStyle: Platform.OS === 'ios' ? variables.subtitle.fontStyle : 'normal',
+    fontWeight: resolveFontWeight(variables.subtitle.fontWeight),
+    fontStyle: resolveFontStyle(variables.subtitle.fontStyle),
   },
 
   'shoutem.ui.Caption': {
@@ -454,8 +476,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.caption.fontWeight,
       variables.caption.fontStyle,
     ),
-    fontWeight: Platform.OS === 'ios' ? variables.caption.fontWeight : 'normal',
-    fontStyle: Platform.OS === 'ios' ? variables.caption.fontStyle : 'normal',
+    fontWeight: resolveFontWeight(variables.caption.fontWeight),
+    fontStyle: resolveFontStyle(variables.caption.fontStyle),
   },
 
   'shoutem.ui.Text': {
@@ -467,8 +489,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.text.fontWeight,
       variables.text.fontStyle,
     ),
-    fontWeight: Platform.OS === 'ios' ? variables.text.fontWeight : 'normal',
-    fontStyle: Platform.OS === 'ios' ? variables.text.fontStyle : 'normal',
+    fontWeight: resolveFontWeight(variables.text.fontWeight),
+    fontStyle: resolveFontStyle(variables.text.fontStyle,
   },
 
   //
@@ -1108,8 +1130,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.text.fontWeight,
         variables.text.fontStyle,
       ),
-      fontWeight: Platform.OS === 'ios' ? variables.text.fontWeight : 'normal',
-      fontStyle: Platform.OS === 'ios' ? variables.text.fontStyle : 'normal',
+      fontWeight: resolveFontWeight(variables.text.fontWeight),
+      fontStyle: resolveFontStyle(variables.text.fontStyle),
     },
 
     'shoutem.ui.Icon': {
@@ -1209,8 +1231,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.primaryButtonText.fontWeight,
         variables.primaryButtonText.fontStyle,
       ),
-      fontWeight: Platform.OS === 'ios' ? variables.primaryButtonText.fontWeight : 'normal',
-      fontStyle: Platform.OS === 'ios' ? variables.primaryButtonText.fontStyle : 'normal',
+      fontWeight: resolveFontWeight(variables.primaryButtonText.fontWeight),
+      fontStyle: resolveFontStyle(variables.primaryButtonText.fontStyle),
       letterSpacing: 1,
       marginVertical: 12,
       marginRight: 10,
@@ -1405,8 +1427,8 @@ export default (variables = defaultThemeVariables) => ({
           variables.title.fontWeight,
           variables.title.fontStyle,
         ),
-        fontWeight: Platform.OS === 'ios' ? variables.title.fontWeight : 'normal',
-        fontStyle: Platform.OS === 'ios' ? variables.title.fontStyle : 'normal',
+        fontWeight: resolveFontWeight(variables.title.fontWeight),
+        fontStyle: resolveFontStyle(variables.title.fontStyle),
         color: variables.featuredNavBarTitleColor,
       }),
 
@@ -1438,8 +1460,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.navBarText.fontWeight,
         variables.navBarText.fontStyle,
       ),
-      fontWeight: Platform.OS === 'ios' ? variables.navBarText.fontWeight : 'normal',
-      fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
+      fontWeight: resolveFontWeight(variables.navBarText.fontWeight),
+      fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
       paddingHorizontal: 9,
     },
 
@@ -1458,8 +1480,8 @@ export default (variables = defaultThemeVariables) => ({
           'normal',
           variables.navBarText.fontStyle,
         ),
-        fontWeight: 'normal',
-        fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
+        fontWeight: resolveFontWeight('normal'),
+        fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
         color: variables.navBarIconsColor,
         letterSpacing: 0,
       },
@@ -1484,8 +1506,8 @@ export default (variables = defaultThemeVariables) => ({
             'normal',
             variables.navBarText.fontStyle,
           ),
-          fontWeight: 'normal',
-          fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
+          fontWeight: resolveFontWeight('normal'),
+          fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
           color: variables.navBarIconsColor,
         },
       },
@@ -1555,8 +1577,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.navBarText.fontWeight,
         variables.navBarText.fontStyle,
       ),
-      fontWeight: Platform.OS === 'ios' ? variables.navBarText.fontWeight : 'normal',
-      fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
+      fontWeight: resolveFontWeight(variables.navBarText.fontWeight),
+      fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
     },
 
     statusBar: {
@@ -1698,8 +1720,8 @@ export default (variables = defaultThemeVariables) => ({
         variables.navBarText.fontWeight,
         variables.navBarText.fontStyle,
       ),
-      fontWeight: Platform.OS === 'ios' ? variables.navBarText.fontWeight : 'normal',
-      fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
+      fontWeight: resolveFontWeight(variables.navBarText.fontWeight),
+      fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
     },
 
     container: {
@@ -1905,8 +1927,8 @@ export default (variables = defaultThemeVariables) => ({
       variables.text.fontWeight,
       variables.text.fontStyle,
     ),
-    fontWeight: Platform.OS === 'ios' ? variables.text.fontWeight : 'normal',
-    fontStyle: Platform.OS === 'ios' ? variables.text.fontStyle : 'normal',
+    fontWeight: resolveFontWeight(variables.text.fontWeight),
+    fontStyle: resolveFontStyle(variables.text.fontStyle),
   },
 
   'shoutem.ui.NumberInput': {
@@ -2035,8 +2057,8 @@ export default (variables = defaultThemeVariables) => ({
             variables.navBarText.fontStyle,
           ),
           color: variables.text.color,
-          fontWeight: 'normal',
-          fontStyle: Platform.OS === 'ios' ? variables.navBarText.fontStyle : 'normal',
+          fontWeight: resolveFontWeight('normal'),
+          fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
           textAlign: 'center',
         },
       },
@@ -2143,8 +2165,8 @@ export default (variables = defaultThemeVariables) => ({
           variables.subtitle.fontWeight,
           variables.subtitle.fontStyle,
         ),
-        fontWeight: Platform.OS === 'ios' ? variables.subtitle.fontWeight : 'normal',
-        fontStyle: Platform.OS === 'ios' ? variables.subtitle.fontStyle : 'normal',
+        fontWeight: resolveFontWeight(variables.subtitle.fontWeight),
+        fontStyle: resolveFontStyle(variables.subtitle.fontStyle),
       },
     },
     selectedModalItem: {
@@ -2161,8 +2183,8 @@ export default (variables = defaultThemeVariables) => ({
           '500',
           variables.subtitle.fontStyle,
         ),
-        fontWeight: Platform.OS === 'ios' ? '500' : 'normal',
-        fontStyle: Platform.OS === 'ios' ? variables.subtitle.fontStyle : 'normal',
+        fontWeight: resolveFontWeight('500'),
+        fontStyle: resolveFontStyle(variables.subtitle.fontStyle),
       },
     },
 
@@ -2621,7 +2643,7 @@ export default (variables = defaultThemeVariables) => ({
     },
     cancelText: {
       textAlign: 'center',
-      fontWeight: '700',
+      fontWeight: resolveFontWeight('700'),
     },
   },
 

--- a/theme.js
+++ b/theme.js
@@ -425,7 +425,7 @@ export default (variables = defaultThemeVariables) => ({
   'shoutem.ui.Subtitle': {
     [INCLUDE]: ['text'],
 
-    lineHeight: formatLineHeight(variables.title.fontSize),
+    lineHeight: formatLineHeight(variables.subtitle.fontSize),
     ...variables.subtitle,
     fontFamily: resolveFontFamily(
       variables.subtitle.fontFamily,
@@ -1434,7 +1434,7 @@ export default (variables = defaultThemeVariables) => ({
         ...variables.navBarText,
         fontFamily: resolveFontFamily(
           variables.navBarText.fontFamily,
-          variables.navBarText.fontWeight,
+          'normal',
           variables.navBarText.fontStyle,
         ),
         fontWeight: 'normal',
@@ -1459,7 +1459,7 @@ export default (variables = defaultThemeVariables) => ({
           ...variables.navBarText,
           fontFamily: resolveFontFamily(
             variables.navBarText.fontFamily,
-            variables.navBarText.fontWeight,
+            'normal'
             variables.navBarText.fontStyle,
           ),
           fontWeight: 'normal',
@@ -2002,7 +2002,7 @@ export default (variables = defaultThemeVariables) => ({
           ...variables.navBarText,
           fontFamily: resolveFontFamily(
             variables.navBarText.fontFamily,
-            variables.navBarText.fontWeight,
+            'normal',
             variables.navBarText.fontStyle,
           ),
           color: variables.text.color,
@@ -2126,7 +2126,7 @@ export default (variables = defaultThemeVariables) => ({
         ...variables.subtitle,
         fontFamily: resolveFontFamily(
           variables.subtitle.fontFamily,
-          variables.subtitle.fontWeight,
+          '500',
           variables.subtitle.fontStyle,
         ),
         fontWeight: '500'


### PR DESCRIPTION
`resolveFontFamily` takes the `fontFamily`, `fontWeight` and `fontStyle` properties provided via Customize style settings page in the Shoutem Builder, or from variables being provided in any other way.

Also overriding `fontStyle` and `fontWeight` for Android because having these properties set to anything other than `normal`, while using Italic, Bold or BoldItalic fonts will result to the app using the default system font.

Screenshot showing successful loading of fonts on Android with a mix of `normal`, `bold` and `italic` with `NotoSarif`.

<img width="536" alt="Screenshot 2020-10-27 at 23 50 54" src="https://user-images.githubusercontent.com/28015757/97370492-62bf9c00-18af-11eb-8529-f2bdd686e873.png">

