### PR TITLE
Add error message and border styling to TextInput

### DIFF
--- a/components/TextInput.js
+++ b/components/TextInput.js
@@ -32,11 +32,15 @@ class TextInput extends PureComponent {
     const { highlightWhenFocused, errorMessage, style } = this.props;
     const { isFocused } = this.state;
 
-    const resolvedStyle = {
+    let resolvedStyle = {
       ...style,
-      borderWidth: (isFocused || errorMessage) ? 1 : 0,
-      borderColor: style.errorBorderColor,
-    };
+      borderWidth: (isFocused || !!errorMessage) ? 1 : 0,
+    }
+
+    if (!!errorMessage) {
+      resolvedStyle.borderColor = style.errorBorderColor;
+    }
+
     delete resolvedStyle.placeholderTextColor;
     delete resolvedStyle.selectionColor;
     delete resolvedStyle.underlineColorAndroid;

--- a/components/TextInput.js
+++ b/components/TextInput.js
@@ -10,6 +10,16 @@ import { connectStyle } from '@shoutem/theme';
 import { Caption } from './Text';
 import { View } from './View';
 
+// Style properties defined in theme which would case a warning if passed to a components style prop
+const omittedStyleProperties = [
+  'errorBorder',
+  'placeholderTextColor',
+  'selectionColor',
+  'underlineColorAndroid',
+  'withBorder',
+  'withoutBorder',
+];
+
 class TextInput extends PureComponent {
   constructor(props) {
     super(props);
@@ -21,49 +31,32 @@ class TextInput extends PureComponent {
     };
   }
 
-  handleFocus() {
-    this.setState({ isFocused: true });
-  }
-
   handleBlur() {
     this.setState({ isFocused: false });
   }
 
-  resolveProps() {
-    const { highlightOnFocus, errorMessage, style } = this.props;
-    const { isFocused } = this.state;
-
-    let resolvedStyle = {
-      ..._.omit(style, ['placeholderTextColor', 'selectionColor', 'underlineColorAndroid']),
-      borderWidth: (isFocused || !!errorMessage) ? 1 : 0,
-    }
-
-    if (!!errorMessage) {
-      resolvedStyle.borderColor = style.errorBorderColor;
-    }
-
-    if (highlightOnFocus) {
-      return {
-        onFocus: this.handleFocus,
-        onBlur: this.handleBlur,
-        style: resolvedStyle,
-      };
-    }
-
-    return { style: resolvedStyle };
+  handleFocus() {
+    this.setState({ isFocused: true });
   }
 
   render() {
-    const { errorMessage, style } = this.props;
+    const { errorMessage, highlightOnFocus, style } = this.props;
+    const { isFocused } = this.state;
 
     return (
       <View>
         <RNTextInput
-          {...this.props}
-          {...this.resolveProps()}
+          {..._.omit(this.props, 'style')}
+          onBlur={this.handleBlur}
+          onFocus={this.handleFocus}
           placeholderTextColor={style.placeholderTextColor}
           selectionColor={style.selectionColor}
           underlineColorAndroid={style.underlineColorAndroid}
+          style={[
+            _.omit(style, omittedStyleProperties),
+            (isFocused && highlightOnFocus) ? style.withBorder : style.withoutBorder,
+            !!errorMessage && style.errorBorder,
+          ]}
         />
         {!!errorMessage &&
           <Caption styleName="form-error sm-gutter-top">
@@ -78,8 +71,6 @@ class TextInput extends PureComponent {
 TextInput.propTypes = {
   ...RNTextInput.propTypes,
   style: PropTypes.object,
-  highlightOnFocus: PropTypes.bool,
-  errorMessage: PropTypes.string,
 };
 
 const AnimatedTextInput = connectAnimation(TextInput);

--- a/components/TextInput.js
+++ b/components/TextInput.js
@@ -1,28 +1,75 @@
-import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import autoBindReact from 'auto-bind/react';
+import PropTypes from 'prop-types';
 import { TextInput as RNTextInput } from 'react-native';
 
-import { connectStyle } from '@shoutem/theme';
 import { connectAnimation } from '@shoutem/animation';
+import { connectStyle } from '@shoutem/theme';
+
+import { Caption } from './Text';
+import { View } from './View';
 
 class TextInput extends PureComponent {
-  render() {
-    const { props } = this;
-    const style = {
-      ...props.style,
+  constructor(props) {
+    super(props);
+
+    autoBindReact(this);
+
+    this.state = {
+      isFocused: props.highlightWhenFocused && props.autoFocus,
     };
-    delete style.placeholderTextColor;
-    delete style.selectionColor;
-    delete style.underlineColorAndroid;
+  }
+
+  handleFocus() {
+    this.setState({ isFocused: true });
+  }
+
+  handleBlur() {
+    this.setState({ isFocused: false });
+  }
+
+  resolveProps() {
+    const { highlightWhenFocused, errorMessage, style } = this.props;
+    const { isFocused } = this.state;
+
+    const resolvedStyle = {
+      ...style,
+      borderWidth: (isFocused || errorMessage) ? 1 : 0,
+      borderColor: style.errorBorderColor,
+    };
+    delete resolvedStyle.placeholderTextColor;
+    delete resolvedStyle.selectionColor;
+    delete resolvedStyle.underlineColorAndroid;
+
+    if (highlightWhenFocused) {
+      return {
+        onFocus: () => this.handleFocus(),
+        onBlur: () => this.handleBlur(),
+        style: resolvedStyle,
+      };
+    }
+
+    return { style: resolvedStyle };
+  }
+
+  render() {
+    const { errorMessage, style } = this.props;
 
     return (
-      <RNTextInput
-        {...props}
-        style={style}
-        placeholderTextColor={props.style.placeholderTextColor}
-        selectionColor={props.style.selectionColor}
-        underlineColorAndroid={props.style.underlineColorAndroid}
-      />
+      <View>
+        <RNTextInput
+          {...this.props}
+          {...this.resolveProps()}
+          placeholderTextColor={style.placeholderTextColor}
+          selectionColor={style.selectionColor}
+          underlineColorAndroid={style.underlineColorAndroid}
+        />
+        {!!errorMessage &&
+          <Caption styleName="form-error sm-gutter-top">
+            {errorMessage}
+          </Caption>
+        }
+      </View>
     );
   }
 }
@@ -30,6 +77,8 @@ class TextInput extends PureComponent {
 TextInput.propTypes = {
   ...RNTextInput.propTypes,
   style: PropTypes.object,
+  highlightWhenFocused: PropTypes.bool,
+  errorMessage: PropTypes.string,
 };
 
 const AnimatedTextInput = connectAnimation(TextInput);

--- a/components/TextInput.js
+++ b/components/TextInput.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import autoBindReact from 'auto-bind/react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { TextInput as RNTextInput } from 'react-native';
 
@@ -16,7 +17,7 @@ class TextInput extends PureComponent {
     autoBindReact(this);
 
     this.state = {
-      isFocused: props.highlightWhenFocused && props.autoFocus,
+      isFocused: props.highlightOnFocus && props.autoFocus,
     };
   }
 
@@ -29,11 +30,11 @@ class TextInput extends PureComponent {
   }
 
   resolveProps() {
-    const { highlightWhenFocused, errorMessage, style } = this.props;
+    const { highlightOnFocus, errorMessage, style } = this.props;
     const { isFocused } = this.state;
 
     let resolvedStyle = {
-      ...style,
+      ..._.omit(style, ['placeholderTextColor', 'selectionColor', 'underlineColorAndroid']),
       borderWidth: (isFocused || !!errorMessage) ? 1 : 0,
     }
 
@@ -41,14 +42,10 @@ class TextInput extends PureComponent {
       resolvedStyle.borderColor = style.errorBorderColor;
     }
 
-    delete resolvedStyle.placeholderTextColor;
-    delete resolvedStyle.selectionColor;
-    delete resolvedStyle.underlineColorAndroid;
-
-    if (highlightWhenFocused) {
+    if (highlightOnFocus) {
       return {
-        onFocus: () => this.handleFocus(),
-        onBlur: () => this.handleBlur(),
+        onFocus: this.handleFocus,
+        onBlur: this.handleBlur,
         style: resolvedStyle,
       };
     }
@@ -81,7 +78,7 @@ class TextInput extends PureComponent {
 TextInput.propTypes = {
   ...RNTextInput.propTypes,
   style: PropTypes.object,
-  highlightWhenFocused: PropTypes.bool,
+  highlightOnFocus: PropTypes.bool,
   errorMessage: PropTypes.string,
 };
 

--- a/theme.js
+++ b/theme.js
@@ -167,6 +167,13 @@ export const defaultThemeVariables = {
     fontSize: 15,
     color: '#666666',
   },
+  errorText: {
+    fontFamily: 'Rubik-Regular',
+    fontStyle: 'normal',
+    fontWeight: 'normal',
+    fontSize: 12,
+    color: '#FF0000',
+  },
 
   imageOverlayColor: 'rgba(0, 0, 0, 0.2)',
   imageOverlayTextColor: '#FFFFFF',
@@ -478,6 +485,19 @@ export default (variables = defaultThemeVariables) => ({
     ),
     fontWeight: resolveFontWeight(variables.caption.fontWeight),
     fontStyle: resolveFontStyle(variables.caption.fontStyle),
+
+    '.form-error': {
+      color: variables.errorText.color,
+      fontFamily: resolveFontFamily(
+        variables.errorText.fontFamily,
+        variables.errorText.fontWeight,
+        variables.errorText.fontStyle,
+      ),
+      fontSize: variables.errorText.fontSize,
+      fontStyle: resolveFontStyle(variables.errorText.fontStyle),
+      fontWeight: resolveFontWeight(variables.errorText.fontWeight),
+      lineHeight: calculateLineHeight(variables.errorText.fontSize),
+    }
   },
 
   'shoutem.ui.Text': {
@@ -1929,6 +1949,8 @@ export default (variables = defaultThemeVariables) => ({
     ),
     fontWeight: resolveFontWeight(variables.text.fontWeight),
     fontStyle: resolveFontStyle(variables.text.fontStyle),
+
+    errorBorderColor: variables.errorText.color,
   },
 
   'shoutem.ui.NumberInput': {

--- a/theme.js
+++ b/theme.js
@@ -1951,7 +1951,16 @@ export default (variables = defaultThemeVariables) => ({
     fontWeight: resolveFontWeight(variables.text.fontWeight),
     fontStyle: resolveFontStyle(variables.text.fontStyle),
 
-    errorBorderColor: variables.errorText.color,
+    errorBorder: {
+      borderWidth: 1,
+      borderColor: variables.errorText.color,
+    },
+    withBorder: {
+      borderWidth: 1,
+    },
+    withoutBorder: {
+      borderWidth: 0,
+    },
   },
 
   'shoutem.ui.NumberInput': {

--- a/theme.js
+++ b/theme.js
@@ -1937,6 +1937,7 @@ export default (variables = defaultThemeVariables) => ({
     selectionColor: variables.text.color,
     placeholderTextColor: changeColorAlpha(variables.text.color, 0.5),
     backgroundColor: variables.paperColor,
+    borderColor: variables.text.color,
     height: 55,
     paddingHorizontal: variables.mediumGutter,
     paddingVertical: 18,


### PR DESCRIPTION
- added `errorText` default variables to `theme.js`
- added `highlightWhenFocused` boolean prop which adds `borderWidth: 1` to `TextInput` when it is focused
- added `errorMessage` string prop which renders a `Caption` with `errorText` styling under the given `TextInput`

Focused input highlighting:
<img width="339" alt="Screenshot 2020-11-05 at 15 14 59" src="https://user-images.githubusercontent.com/28015757/98252195-ee08f380-1f79-11eb-8d5a-12f951ece17a.png">

Error `Caption` with `errorText` styling (not default, being overridden by Shoutem builder settings):
<img width="332" alt="Screenshot 2020-11-05 at 15 15 11" src="https://user-images.githubusercontent.com/28015757/98252245-fb25e280-1f79-11eb-86bc-fba565283c28.png">

