### PR TITLE
Adjust ImageGalleryOverlay top padding for Android devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.0.15",
+  "version": "4.0.16",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.0.16",
+  "version": "4.0.15",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",

--- a/theme.js
+++ b/theme.js
@@ -2595,7 +2595,7 @@ export default (variables = defaultThemeVariables) => ({
             NAVIGATION_BAR_HEIGHT +
             (Platform.OS === "ios"
               ? variables.extraLargeGutter + variables.extraLargeGutter
-              : variables.mediumGutter),
+              : variables.extraLargeGutter + variables.mediumGutter),
         },
       },
     },


### PR DESCRIPTION
Increased top padding in ImageGalleryOverlay for Android devices.

Before:
![Screenshot 2020-12-07 at 09 25 13](https://user-images.githubusercontent.com/57353746/101326822-1da76600-386e-11eb-8e6d-fc8d6a124f67.png)


After
![Screenshot 2020-12-07 at 09 23 55](https://user-images.githubusercontent.com/57353746/101326914-3e6fbb80-386e-11eb-9bc5-b6de78dd1bb6.png)

