### PR TITLE
Feature/seext 4198 videos not started in full screen on android devices

### DIFF
--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -70,6 +70,8 @@ class Video extends PureComponent {
     return (
       <View style={style.container}>
         <WebView
+          allowsFullscreenVideo
+          mediaPlaybackRequiresUserAction={false}
           style={{width, height}}
           source={createSourceObject(source, playerParams, poster)}
           scrollEnabled={false}

--- a/components/Video/VideoSourceReader.js
+++ b/components/Video/VideoSourceReader.js
@@ -30,7 +30,7 @@ function getYouTubeEmbedUrl(id, playerParams) {
 }
 
 function getVimeoEmbedUrl(id) {
-  return `https://player.vimeo.com/video/${id}?title=0&byline=0&portrait=0`;
+  return `https://player.vimeo.com/video/${id}?title=0&byline=0&portrait=0&playsinline=0`;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.0.15",
+  "version": "4.0.16",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.0.16",
+  "version": "4.0.15",
   "description": "Styleable set of components for React Native applications",
   "dependencies": {
     "@shoutem/animation": "~0.12.4",


### PR DESCRIPTION
Android users didn't have the option to view videos in full-screen AT ALL.
I've done the best I could, even tho we've got different Vimeo and Youtube player behaviors now.

- added option (button) to enter / leave full-screen
- adjusted Vimeo to start in full-screen. Couldn't do the same for YT, as this possibility is a part of Vimeo embed url params. YT doesn't support this, or I couldn't find it.

iOS videos always worked perfectly, didn't need these extra Webview params.

Tried to make a video run in landscape full-screen on play button press, but didn't find a way to do it using react-native-webview.
If anyone knows anything about this, please let me know.

Before (no full-screen option):
![Screenshot 2020-12-08 at 17 20 58](https://user-images.githubusercontent.com/57353746/101510838-b2978580-397a-11eb-9fd7-f9b623fc84ea.png)
![Screenshot 2020-12-08 at 17 21 07](https://user-images.githubusercontent.com/57353746/101510848-b4f9df80-397a-11eb-9a77-489968b4a2f7.png)

After video:
https://streamable.com/i02kmd