### PR TITLE
Disable full screen Vimeo player on Android devices

### DIFF
--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -8,8 +8,7 @@ import { connectStyle } from '@shoutem/theme';
 
 import VideoSourceReader from './VideoSourceReader';
 
-function createSourceObject(source, playerParams, poster) {
-  const sourceReader = new VideoSourceReader(source.uri, playerParams);
+function getSource(sourceReader, poster) {
   const url = sourceReader.getUrl();
 
   if (sourceReader.isEmbeddableVideo()) {
@@ -57,23 +56,34 @@ class Video extends PureComponent {
     },
   };
 
+  constructor(props) {
+    super(props);
+
+    const { source, playerParams } = props;
+    this.sourceReader = new VideoSourceReader(source.uri, playerParams);
+  }
+
   render() {
     const {
       width,
       height,
-      source,
       style,
-      playerParams,
       poster,
     } = this.props;
+
+    // https://github.com/vimeo/player.js/issues/514
+    // Vimeo player crashes the app, if played in full screen portrait mode and if user
+    // tries to navigate back using Android hardware back button. Disableing full screen
+    // option for Vimeo until their player is fixed.
+    const isYoutubeVideo = this.sourceReader.isYouTube;
 
     return (
       <View style={style.container}>
         <WebView
-          allowsFullscreenVideo
+          allowsFullscreenVideo={isYoutubeVideo}
           mediaPlaybackRequiresUserAction={false}
           style={{width, height}}
-          source={createSourceObject(source, playerParams, poster)}
+          source={getSource(this.sourceReader, poster)}
           scrollEnabled={false}
           originWhitelist={['*']}
         />

--- a/components/Video/VideoSourceReader.js
+++ b/components/Video/VideoSourceReader.js
@@ -30,7 +30,7 @@ function getYouTubeEmbedUrl(id, playerParams) {
 }
 
 function getVimeoEmbedUrl(id) {
-  return `https://player.vimeo.com/video/${id}?title=0&byline=0&portrait=0&playsinline=0`;
+  return `https://player.vimeo.com/video/${id}?title=0&byline=0&portrait=0`;
 }
 
 /**


### PR DESCRIPTION
As we (Tara, Goran, Davor, and me) discussed, we'll be disabling Vimeo player full-screen option on Android devices.
If Android users were in Vimeo full-screen portrait mode and used the hardware back button, it'd cause the app to show a blank screen, making the app unusable.

Vimeo player repo has this issue reported and unresolved.
https://github.com/vimeo/player.js/issues/514

So, on Android, we'll be showing a full-screen option for Youtube videos only.
On iOS everything works perfectly well, as all videos are played inside their native player.

Notes:
- Removed `playsinline=0`, as it was before new Video/Vimeo changes. Vimeo player controls are not shown if this is false
- Keeping `mediaPlaybackRequiresUserAction={false}`. Without it, if the user presses play on Vimeo player, the video loads, but it stops again - requiring the user to press play again. With this prop, the video is played straight after load.
- Initialized sourceReader inside class. This way we'll avoid initializing it in every render() call, as it was before.

Android video:
https://streamable.com/g9gtis

iOS video:
https://streamable.com/efxjq0