### PR TITLE
feature SEEXT-9364 Rich text editor Numbered list doesn't apply properly in the app

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -77,7 +77,12 @@ class SimpleHtml extends PureComponent {
     return <Text style={style.prefix}>• </Text>;
   }
 
-  renderOrderedListPrefix(passProps) {
+  renderOrderedListPrefix(
+    htmlAttribs,
+    children,
+    convertedCSSStyles,
+    passProps,
+  ) {
     const { style } = this.props;
 
     return <Text style={style.prefix}>{passProps.index + 1}. </Text>;


### PR DESCRIPTION
Fixes ordered list prefix.

**Problem:**
![image](https://user-images.githubusercontent.com/57353746/112124587-cb8f1400-8bc2-11eb-81d6-13bdeb91ded6.png)


**Fix:**
<img width="357" alt="Screenshot 2021-03-23 at 10 28 36" src="https://user-images.githubusercontent.com/57353746/112124605-d053c800-8bc2-11eb-8fe2-a7681d4703ac.png">
