### PR TITLE
Fix checkbox rectangle off/on loading

### DIFF
--- a/components/Icon/assets/index.js
+++ b/components/Icon/assets/index.js
@@ -13,8 +13,8 @@ import camSwitch from './cam-switch.svg';
 import cart from './cart.svg';
 import checkboxOff from './checkbox-off.svg';
 import checkboxOn from './checkbox-on.svg';
-import checkbocRectangleOff from './checkbox-rectangle-off';
-import checkbocRectangleOn from './checkbox-rectangle-on';
+import checkboxRectangleOff from './checkbox-rectangle-off.svg';
+import checkboxRectangleOn from './checkbox-rectangle-on.svg';
 import clearText from './clear-text.svg';
 import close from './close.svg';
 import comment from './comment.svg';
@@ -113,8 +113,8 @@ export const defaultConfig = [
   { name: 'cart', icon: cart },
   { name: 'checkbox-off', icon: checkboxOff },
   { name: 'checkbox-on', icon: checkboxOn },
-  { name: 'checkbox-rectangle-off', icon: checkbocRectangleOff },
-  { name: 'checkbox-rectangle-on', icon: checkbocRectangleOn },
+  { name: 'checkbox-rectangle-off', icon: checkboxRectangleOff },
+  { name: 'checkbox-rectangle-on', icon: checkboxRectangleOn },
   { name: 'clear-text', icon: clearText },
   { name: 'close', icon: close },
   { name: 'comment', icon: comment },


### PR DESCRIPTION
Update components/Icon/assets/index.js to load a couple
of checkbox SVGs correctly. Extension missing, app breaks
when loading <Examples/> on a brand new project.
Fix names.