### PR TITLE
Remove unused path from checkbox-rectangle-off.svg

### DIFF
--- a/components/Icon/assets/checkbox-rectangle-off.svg
+++ b/components/Icon/assets/checkbox-rectangle-off.svg
@@ -1,4 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-<path d="M7.66675 12.6654L10.6667 15.6654L17.0001 9.33203" stroke="transparent" stroke-width="2" stroke-linecap="square"/>
 <rect x="0.5" y="0.5" width="23" height="23" rx="5.5" stroke="#828282" stroke-opacity="0.12"/>
 </svg>


### PR DESCRIPTION
- removed unused `path` from `checkbox-rectangle-off.svg` file

I didn't spot this until I set an opacity other than 1 for icon fill.

Before:
<img width="37" alt="Screenshot 2021-06-10 at 16 16 20" src="https://user-images.githubusercontent.com/28015757/121541533-ae225700-ca07-11eb-9b41-f36c2a3e9500.png">

After:
<img width="34" alt="Screenshot 2021-06-10 at 16 16 27" src="https://user-images.githubusercontent.com/28015757/121541545-b11d4780-ca07-11eb-9347-c74cf34e18ae.png">
