### PR TITLE
Feature/add grid row no padding and extend list view with index

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -148,7 +148,7 @@ class ListView extends PureComponent {
       renderHeader,
       autoHideHeader,
     );
-    mappedProps.renderItem = data => renderRow(data.item);
+    mappedProps.renderItem = data => renderRow(data.item, data.index);
     mappedProps.ListFooterComponent = this.renderFooter;
 
     if (hasFeaturedItem && !sections) {

--- a/theme.js
+++ b/theme.js
@@ -1430,6 +1430,10 @@ export default (variables = defaultThemeVariables) => ({
     justifyContent: 'space-between',
     paddingRight: variables.smallGutter,
     paddingTop: variables.smallGutter,
+
+    '.no-padding': {
+      padding: 0,
+    },
   },
 
   //

--- a/theme.js
+++ b/theme.js
@@ -1424,16 +1424,16 @@ export default (variables = defaultThemeVariables) => ({
       marginBottom: 0,
     },
 
+    '.no-padding': {
+      padding: 0,
+    },
+
     flex: 1,
     flexDirection: 'row',
     alignItems: 'flex-start',
     justifyContent: 'space-between',
     paddingRight: variables.smallGutter,
     paddingTop: variables.smallGutter,
-
-    '.no-padding': {
-      padding: 0,
-    },
   },
 
   //


### PR DESCRIPTION
`GridRow` component has padding top & right - 5px.
Added `no-padding` option for it.

Passing item index to `ListView`'s `renderRow` now.