### PR TITLE
Support for tables in SimpleHtml

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -233,10 +233,13 @@ class SimpleHtml extends PureComponent {
       ol: this.renderOrderedListPrefix,
     };
 
-    const cssRules = cssRulesFromSpecs({
-      ...defaultTableStylesSpecs,
-      ...style.table,
-    });
+    const tableStyle = _.get(style, 'table', {});
+    const tableCssStyle = _.get(style, 'tableCss', '');
+    const cssRules =
+      cssRulesFromSpecs({
+        ...defaultTableStylesSpecs,
+        ...tableStyle,
+      }) + tableCssStyle;
 
     const customRenderers = {
       iframe: this.renderIframe,

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -235,11 +235,11 @@ class SimpleHtml extends PureComponent {
 
     const tableStyle = _.get(style, 'table', {});
     const tableCssStyle = _.get(style, 'tableCss', '');
-    const cssRules =
-      cssRulesFromSpecs({
-        ...defaultTableStylesSpecs,
-        ...tableStyle,
-      }) + tableCssStyle;
+    const cssStyle = cssRulesFromSpecs({
+      ...defaultTableStylesSpecs,
+      ...tableStyle,
+    });
+    const cssRules = `${cssStyle}${tableCssStyle}`;
 
     const customRenderers = {
       iframe: this.renderIframe,

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -23,10 +23,12 @@ import { View } from '../../components/View';
 import { Text } from '../../components/Text';
 import getEmptyObjectKeys from '../services/getEmptyObjectKeys';
 import isValidVideoFormat from '../services/isValidVideoFormat';
+import Image from './Image';
 
 class SimpleHtml extends PureComponent {
   static propTypes = {
     body: PropTypes.string,
+    attachments: PropTypes.array,
     style: PropTypes.object,
     customTagStyles: PropTypes.object,
     customHandleLinkPress: PropTypes.func,
@@ -150,6 +152,31 @@ class SimpleHtml extends PureComponent {
     return <Text style={style.prefix}>{passProps.index + 1}. </Text>;
   }
 
+  /**
+   * Custom rendered method for handling <attachment> tags
+   * Currently only supports rendering image attachments.
+   */
+  renderAttachments({ id, type }) {
+    const { attachments } = this.props;
+
+    if (!attachments) {
+      return null;
+    }
+
+    if (type === 'image') {
+      const image = _.find(attachments, { id });
+
+      if (image && image.src) {
+        const source = { uri: image.src };
+        const style = { height: image.height, alignSelf: 'center' };
+
+        return <Image source={source} key={id} style={style} />;
+      }
+    }
+
+    return null;
+  }
+
   renderIframe(htmlAttribs, children, convertedCSSStyles, passProps) {
     const { style } = this.props;
 
@@ -214,6 +241,7 @@ class SimpleHtml extends PureComponent {
     const customRenderers = {
       iframe: this.renderIframe,
       table: makeTableRenderer({ WebViewComponent: WebView, cssRules }),
+      attachment: this.renderAttachments,
     };
 
     const htmlProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -967,6 +967,11 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
@@ -1343,6 +1348,16 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
+    },
+    "character-entities-html4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -2630,6 +2645,20 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2668,6 +2697,11 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+    },
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
@@ -2697,6 +2731,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-negative-zero": {
       "version": "2.0.1",
@@ -3491,6 +3530,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+    },
     "react-addons-test-utils": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
@@ -3600,6 +3644,17 @@
             "isarray": "^1.0.0"
           }
         }
+      }
+    },
+    "react-native-render-html-table-bridge": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-render-html-table-bridge/-/react-native-render-html-table-bridge-0.6.0.tgz",
+      "integrity": "sha512-venl0/3fS7Grt+fck+xsEBM09rTUDOjlR+J2QRfy3DmE6RwJQ12O4qJpWwFmetr+HSGnQVIIt4hDHxsryWK9SQ==",
+      "requires": {
+        "@types/prop-types": "^15.7.3",
+        "prop-types": "^15.7.2",
+        "ramda": "^0.26.1",
+        "stringify-entities": "^2.0.0"
       }
     },
     "react-native-scroller": {
@@ -4136,6 +4191,18 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "stringify-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
+      "integrity": "sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==",
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.2",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@shoutem/animation": "~0.14.0",
     "@shoutem/eslint-config-react": "^1.0.1",
     "@shoutem/theme": "~0.12.0",
+    "react-native-render-html-table-bridge": "0.6.0",
     "auto-bind": "^4.0.0",
     "babel-plugin-transform-decorators-legacy": "~1.3.4",
     "buffer": "5.6.0",


### PR DESCRIPTION
Feature adds support for tables in `SimpleHtml` component using `react-native-render-html-table-bridge` package.
Table rendering is handled really well, and in case of column overflow table is rendered as horizontal scroll view.

Few issues I have with current implementation are mentioned in ➡️ [this PR](https://github.com/shoutem/mobile/pull/753).

Currently, the table is styled as shown in screenshot in above mentioned PR.

✍️  **EDIT**: Added support for rendering image attachments using `Image` component. Styling was added to keep consistent style to `Html` `Img` component.