### PR TITLE
Feature/datetime picker

### DIFF
--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import RNCDateTimePicker from '@react-native-community/datetimepicker';
 import autoBindReact from 'auto-bind/react';
+import PropTypes from 'prop-types';
 import { Platform } from 'react-native';
 import Modal from 'react-native-modal';
 import { connectStyle } from '@shoutem/theme';
@@ -43,36 +44,24 @@ class DateTimePicker extends PureComponent {
   }
 
   render() {
-    const { textValue } = this.props;
+    const { confirmButtonText, is24Hour, mode, textValue, style } = this.props;
     const { showPicker, value } = this.state;
 
     return (
       <View styleName="horizontal">
         <TouchableOpacity
-          onPress={this.handleShowPicker}
           styleName="flexible md-gutter"
-          style={{
-            padding: 15,
-            borderColor: '#C2C2C2',
-            borderWidth: 1,
-          }}
+          style={style.textContainer}
+          onPress={this.handleShowPicker}
         >
           <Text> {textValue}</Text>
         </TouchableOpacity>
         <TouchableOpacity
           onPress={this.handleShowPicker}
-          style={{
-            width: 50,
-            height: 50,
-            backgroundColor: '#222222',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          styleName="h-center v-center"
+          style={style.buttonContainer}
         >
-          <Icon
-            name="drop-down"
-            style={{ color: '#FFFFFF', height: 30, width: 30 }}
-          />
+          <Icon name="drop-down" style={style.icon} />
         </TouchableOpacity>
         <Modal
           backdropOpacity={0.5}
@@ -80,20 +69,20 @@ class DateTimePicker extends PureComponent {
           hasBackdrop
           onBackdropPress={this.handleHidePicker}
         >
-          <View styleName="md-gutter" style={{ backgroundColor: '#FFFFFF' }}>
+          <View styleName="md-gutter" style={style.modalContainer}>
             <RNCDateTimePicker
-              mode="time"
+              mode={mode}
               value={value}
-              is24Hour={false}
+              is24Hour={is24Hour}
               display={Platform.OS === 'ios' ? 'spinner' : 'default'}
               onChange={this.handleValueChanged}
             />
-            <View style={{ height: 80 }} styleName="md-gutter-top">
+            <View style={style.modalButtonContainer} styleName="md-gutter-top">
               <Button
-                style={{ width: 100, margin: 'auto' }}
+                style={style.modalButton}
                 onPress={this.handleConfirmPress}
               >
-                <Text>CONFIRM</Text>
+                <Text>{confirmButtonText}</Text>
               </Button>
             </View>
           </View>
@@ -102,6 +91,22 @@ class DateTimePicker extends PureComponent {
     );
   }
 }
+
+DateTimePicker.propTypes = {
+  confirmButtonText: PropTypes.string,
+  is24Hour: PropTypes.bool,
+  mode: PropTypes.string,
+  onValueChanged: PropTypes.func,
+  textValue: PropTypes.string,
+  value: PropTypes.instanceOf(Date),
+};
+
+DateTimePicker.defaultProps = {
+  confirmButtonText: 'Confirm',
+  is24Hour: false,
+  mode: 'datetime',
+  value: new Date(),
+};
 
 const StyledDateTimePicker = connectStyle('shoutem.ui.DateTimePicker')(
   DateTimePicker,

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -2,11 +2,13 @@ import React, { PureComponent } from 'react';
 import RNCDateTimePicker from '@react-native-community/datetimepicker';
 import autoBindReact from 'auto-bind/react';
 import { Platform } from 'react-native';
+import Modal from 'react-native-modal';
 import { connectStyle } from '@shoutem/theme';
 import { Icon } from './Icon';
 import { Text } from './Text';
 import { TouchableOpacity } from './TouchableOpacity';
 import { View } from './View';
+import { Button } from './Button';
 
 class DateTimePicker extends PureComponent {
   constructor(props) {
@@ -16,27 +18,38 @@ class DateTimePicker extends PureComponent {
 
     this.state = {
       showPicker: false,
+      value: props.value,
     };
   }
 
-  handleOpenPicker() {
-    const { showPicker } = this.state;
-    this.setState({ showPicker: !showPicker });
+  handleValueChanged(event, value) {
+    this.setState({ value });
   }
 
-  handleTimeSelected(time) {
-    console.log(time)
-    this.setState({showPicker: false})
+  handleShowPicker() {
+    this.setState({ showPicker: true });
+  }
+
+  handleHidePicker() {
+    this.setState({ showPicker: false });
+  }
+
+  handleConfirmPress() {
+    const { onValueChanged } = this.props;
+    const { value } = this.state;
+
+    onValueChanged(value);
+    this.handleHidePicker();
   }
 
   render() {
-    const { showPicker } = this.state;
-    console.log(showPicker)
+    const { textValue } = this.props;
+    const { showPicker, value } = this.state;
 
     return (
       <View styleName="horizontal">
         <TouchableOpacity
-          onPress={this.handleOpenPicker}
+          onPress={this.handleShowPicker}
           styleName="flexible md-gutter"
           style={{
             padding: 15,
@@ -44,10 +57,10 @@ class DateTimePicker extends PureComponent {
             borderWidth: 1,
           }}
         >
-          <Text> 10:30 AM </Text>
+          <Text> {textValue}</Text>
         </TouchableOpacity>
         <TouchableOpacity
-          onPress={this.handleOpenPicker}
+          onPress={this.handleShowPicker}
           style={{
             width: 50,
             height: 50,
@@ -61,21 +74,37 @@ class DateTimePicker extends PureComponent {
             style={{ color: '#FFFFFF', height: 30, width: 30 }}
           />
         </TouchableOpacity>
+        <Modal
+          backdropOpacity={0.5}
+          isVisible={showPicker}
+          hasBackdrop
+          onBackdropPress={this.handleHidePicker}
+        >
+          <View styleName="md-gutter" style={{ backgroundColor: '#FFFFFF' }}>
+            <RNCDateTimePicker
+              mode="time"
+              value={value}
+              is24Hour={false}
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              onChange={this.handleValueChanged}
+            />
+            <View style={{ height: 80 }} styleName="md-gutter-top">
+              <Button
+                style={{ width: 100, margin: 'auto' }}
+                onPress={this.handleConfirmPress}
+              >
+                <Text>CONFIRM</Text>
+              </Button>
+            </View>
+          </View>
+        </Modal>
       </View>
-      // {showPicker && (
-      //   <View style={{ position:'absolute', zIndex: 500, width: 500, height: 500, borderColor: 'red', borderWidth: 2}}>
-      //     <RNCDateTimePicker
-      //       mode="time"
-      //       value={new Date()}
-      //       is24Hour={false}
-      //       display={Platform.OS === 'ios' ? 'compact' : 'default'}
-      //       onChange={this.handleTimeSelected}
-      //     />
-      //   </View>
-      // )}
     );
   }
 }
 
-const StyledDateTimePicker = connectStyle('shoutem.ui.DateTimePicker')(DateTimePicker);
+const StyledDateTimePicker = connectStyle('shoutem.ui.DateTimePicker')(
+  DateTimePicker,
+);
+
 export { StyledDateTimePicker as DateTimePicker };

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -24,7 +24,11 @@ class DateTimePicker extends PureComponent {
   }
 
   handleValueChanged(event, value) {
-    this.setState({ value });
+    if (event.type === 'dismissed') {
+      return this.setState({ showPicker: false });
+    }
+
+    return this.setState({ value });
   }
 
   handleShowPicker() {
@@ -47,6 +51,8 @@ class DateTimePicker extends PureComponent {
     const { confirmButtonText, is24Hour, mode, textValue, style } = this.props;
     const { showPicker, value } = this.state;
 
+    const isIos = Platform.OS === 'ios';
+
     return (
       <View styleName="horizontal">
         <TouchableOpacity
@@ -63,30 +69,44 @@ class DateTimePicker extends PureComponent {
         >
           <Icon name="drop-down" style={style.icon} />
         </TouchableOpacity>
-        <Modal
-          backdropOpacity={0.5}
-          isVisible={showPicker}
-          hasBackdrop
-          onBackdropPress={this.handleHidePicker}
-        >
-          <View styleName="md-gutter" style={style.modalContainer}>
-            <RNCDateTimePicker
-              mode={mode}
-              value={value}
-              is24Hour={is24Hour}
-              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-              onChange={this.handleValueChanged}
-            />
-            <View style={style.modalButtonContainer} styleName="md-gutter-top">
-              <Button
-                style={style.modalButton}
-                onPress={this.handleConfirmPress}
+        {isIos && (
+          <Modal
+            backdropOpacity={0.5}
+            isVisible={showPicker}
+            hasBackdrop
+            onBackdropPress={this.handleHidePicker}
+          >
+            <View styleName="md-gutter" style={style.modalContainer}>
+              <RNCDateTimePicker
+                mode={mode}
+                value={value}
+                is24Hour={is24Hour}
+                display="spinner"
+                onChange={this.handleValueChanged}
+              />
+              <View
+                style={style.modalButtonContainer}
+                styleName="md-gutter-top"
               >
-                <Text>{confirmButtonText}</Text>
-              </Button>
+                <Button
+                  style={style.modalButton}
+                  onPress={this.handleConfirmPress}
+                >
+                  <Text>{confirmButtonText}</Text>
+                </Button>
+              </View>
             </View>
-          </View>
-        </Modal>
+          </Modal>
+        )}
+        {!isIos && showPicker && (
+          <RNCDateTimePicker
+            mode={mode}
+            value={value}
+            is24Hour={is24Hour}
+            display="default"
+            onChange={this.handleValueChanged}
+          />
+        )}
       </View>
     );
   }

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -25,6 +25,14 @@ class DateTimePicker extends PureComponent {
     };
   }
 
+  componentDidUpdate() {
+    if (!isIos) {
+      const { value } = this.props;
+
+      this.setState({ value });
+    }
+  }
+
   handleValueChanged(event, value) {
     if (isIos) {
       return this.setState({ value });
@@ -57,10 +65,15 @@ class DateTimePicker extends PureComponent {
   }
 
   render() {
-    const { confirmButtonText, is24Hour, mode, textValue, style } = this.props;
+    const {
+      confirmButtonText,
+      is24Hour,
+      mode,
+      textValue,
+      style,
+      ...otherProps
+    } = this.props;
     const { showPicker, value } = this.state;
-
-    const isIos = Platform.OS === 'ios';
 
     return (
       <View styleName="horizontal">
@@ -87,11 +100,14 @@ class DateTimePicker extends PureComponent {
           >
             <View styleName="md-gutter" style={style.modalContainer}>
               <RNCDateTimePicker
-                mode={mode}
-                value={value}
-                is24Hour={is24Hour}
                 display="spinner"
+                is24Hour={is24Hour}
+                mode={mode}
                 onChange={this.handleValueChanged}
+                textColor="light"
+                themeVariant="light"
+                value={value}
+                {...otherProps}
               />
               <View
                 style={style.modalButtonContainer}
@@ -109,11 +125,12 @@ class DateTimePicker extends PureComponent {
         )}
         {!isIos && showPicker && (
           <RNCDateTimePicker
-            mode={mode}
-            value={value}
-            is24Hour={is24Hour}
             display="default"
+            is24Hour={is24Hour}
+            mode={mode}
             onChange={this.handleValueChanged}
+            value={value}
+            {...otherProps}
           />
         )}
       </View>

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -98,7 +98,7 @@ DateTimePicker.propTypes = {
   mode: PropTypes.string,
   onValueChanged: PropTypes.func,
   textValue: PropTypes.string,
-  value: PropTypes.instanceOf(Date),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
 };
 
 DateTimePicker.defaultProps = {

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -1,0 +1,81 @@
+import React, { PureComponent } from 'react';
+import RNCDateTimePicker from '@react-native-community/datetimepicker';
+import autoBindReact from 'auto-bind/react';
+import { Platform } from 'react-native';
+import { connectStyle } from '@shoutem/theme';
+import { Icon } from './Icon';
+import { Text } from './Text';
+import { TouchableOpacity } from './TouchableOpacity';
+import { View } from './View';
+
+class DateTimePicker extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    autoBindReact(this);
+
+    this.state = {
+      showPicker: false,
+    };
+  }
+
+  handleOpenPicker() {
+    const { showPicker } = this.state;
+    this.setState({ showPicker: !showPicker });
+  }
+
+  handleTimeSelected(time) {
+    console.log(time)
+    this.setState({showPicker: false})
+  }
+
+  render() {
+    const { showPicker } = this.state;
+    console.log(showPicker)
+
+    return (
+      <View styleName="horizontal">
+        <TouchableOpacity
+          onPress={this.handleOpenPicker}
+          styleName="flexible md-gutter"
+          style={{
+            padding: 15,
+            borderColor: '#C2C2C2',
+            borderWidth: 1,
+          }}
+        >
+          <Text> 10:30 AM </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={this.handleOpenPicker}
+          style={{
+            width: 50,
+            height: 50,
+            backgroundColor: '#222222',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Icon
+            name="drop-down"
+            style={{ color: '#FFFFFF', height: 30, width: 30 }}
+          />
+        </TouchableOpacity>
+      </View>
+      // {showPicker && (
+      //   <View style={{ position:'absolute', zIndex: 500, width: 500, height: 500, borderColor: 'red', borderWidth: 2}}>
+      //     <RNCDateTimePicker
+      //       mode="time"
+      //       value={new Date()}
+      //       is24Hour={false}
+      //       display={Platform.OS === 'ios' ? 'compact' : 'default'}
+      //       onChange={this.handleTimeSelected}
+      //     />
+      //   </View>
+      // )}
+    );
+  }
+}
+
+const StyledDateTimePicker = connectStyle('shoutem.ui.DateTimePicker')(DateTimePicker);
+export { StyledDateTimePicker as DateTimePicker };

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types';
 import { Platform } from 'react-native';
 import Modal from 'react-native-modal';
 import { connectStyle } from '@shoutem/theme';
+import { Button } from './Button';
 import { Icon } from './Icon';
 import { Text } from './Text';
 import { TouchableOpacity } from './TouchableOpacity';
 import { View } from './View';
-import { Button } from './Button';
 
 const isIos = Platform.OS === 'ios';
 
@@ -39,7 +39,7 @@ class DateTimePicker extends PureComponent {
     }
 
     if (event.type === 'dismissed') {
-      return this.setState({ showPicker: false });
+      return this.handleHidePicker();
     }
 
     const { onValueChanged } = this.props;
@@ -97,6 +97,9 @@ class DateTimePicker extends PureComponent {
             isVisible={showPicker}
             hasBackdrop
             onBackdropPress={this.handleHidePicker}
+            swipeDirection={['left', 'right']}
+            swipeThreshold={20}
+            onSwipeComplete={this.handleHidePicker}
           >
             <View styleName="md-gutter" style={style.modalContainer}>
               <RNCDateTimePicker

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -11,6 +11,8 @@ import { TouchableOpacity } from './TouchableOpacity';
 import { View } from './View';
 import { Button } from './Button';
 
+const isIos = Platform.OS === 'ios';
+
 class DateTimePicker extends PureComponent {
   constructor(props) {
     super(props);
@@ -24,11 +26,18 @@ class DateTimePicker extends PureComponent {
   }
 
   handleValueChanged(event, value) {
+    if (isIos) {
+      return this.setState({ value });
+    }
+
     if (event.type === 'dismissed') {
       return this.setState({ showPicker: false });
     }
 
-    return this.setState({ value });
+    const { onValueChanged } = this.props;
+
+    this.setState({ showPicker: false });
+    return onValueChanged(value);
   }
 
   handleShowPicker() {

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ export { NumberInput } from './components/NumberInput';
 export { SearchField } from './components/SearchField';
 export { TabMenu } from './components/TabMenu';
 export { YearRangePicker } from './components/YearRangePicker';
+export { DateTimePicker } from './components/DateTimePicker';
 
 export { Examples } from './examples/components';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -814,6 +814,14 @@
         }
       }
     },
+    "@react-native-community/datetimepicker": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-3.5.2.tgz",
+      "integrity": "sha512-TWRuAtr/DnrEcRewqvXMLea2oB+YF+SbtuYLHguALLxNJQLl/RFB7aTNZeF+OoH75zKFqtXECXV1/uxQUpA+sg==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
     "@shoutem/animation": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@shoutem/animation/-/animation-0.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "mocha '_tests_/*.js' --require react-native-mock-render/mock --require @babel/register"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "^3.5.2",
     "@shoutem/animation": "~0.14.0",
     "@shoutem/eslint-config-react": "^1.0.1",
     "@shoutem/theme": "~0.12.0",
@@ -62,6 +63,7 @@
     "react-native-mock-render": "0.1.9"
   },
   "nativeDependencies": [
+    "@react-native-community/datetimepicker",
     "react-native-linear-gradient",
     "react-native-photo-view",
     "react-native-svg",
@@ -109,6 +111,10 @@
     {
       "email": "zeljko@shoutem.com",
       "name": "zrumenjak"
+    },
+    {
+      "email": "tomislav.arambasic@shoutem.com",
+      "name": "tomislav-arambasic"
     }
   ],
   "eslintConfig": {

--- a/theme.js
+++ b/theme.js
@@ -1178,7 +1178,12 @@ export default (variables = defaultThemeVariables) => ({
   // Buttons
   //
   'shoutem.ui.TouchableOpacity': {
-    [INCLUDE]: ['commonVariants', 'guttersPadding'],
+    [INCLUDE]: [
+      'commonVariants',
+      'guttersPadding',
+      'horizontalFlexAlignment',
+      'verticalFlexAlignment',
+    ],
 
     activeOpacity: 0.8,
   },

--- a/theme.js
+++ b/theme.js
@@ -3060,4 +3060,20 @@ export default (variables = defaultThemeVariables) => ({
       opacity: 0.3,
     },
   },
+
+  'shoutem.ui.DateTimePicker': {
+    buttonContainer: {
+      width: 50,
+      height: 50,
+      backgroundColor: '#222222',
+    },
+    icon: { color: '#FFFFFF', height: 30, width: 30 },
+    modalButton: { width: 100, margin: 'auto' },
+    modalButtonContainer: { height: 80 },
+    modalContainer: { backgroundColor: '#FFFFFF' },
+    textContainer: {
+      borderColor: '#C2C2C2',
+      borderWidth: 1,
+    },
+  },
 });

--- a/theme.js
+++ b/theme.js
@@ -1178,7 +1178,7 @@ export default (variables = defaultThemeVariables) => ({
   // Buttons
   //
   'shoutem.ui.TouchableOpacity': {
-    [INCLUDE]: ['commonVariants'],
+    [INCLUDE]: ['commonVariants', 'guttersPadding'],
 
     activeOpacity: 0.8,
   },


### PR DESCRIPTION
On iOS, DateTimePicker is presented as "standalone component", it has no native background or any other UI.
That's why we define modal & place it inside, with confirm button.

On Android, there's no need for additional UI, it's handled natively.

Android:
![Screenshot 2021-07-16 at 15 20 51](https://user-images.githubusercontent.com/57353746/125954602-e1a5b663-63c2-4a02-b558-dea6760397aa.png)
![Screenshot 2021-07-16 at 15 20 46](https://user-images.githubusercontent.com/57353746/125954606-35fcc7f0-67d6-4e73-bdeb-a74f89136f3f.png)

iOS:
<img width="298" alt="Screenshot 2021-07-16 at 15 22 38" src="https://user-images.githubusercontent.com/57353746/125954849-d5f04100-3723-47ba-a2c1-fcf80bfeee33.png">
<img width="297" alt="Screenshot 2021-07-16 at 15 22 32" src="https://user-images.githubusercontent.com/57353746/125954853-9da077b8-ff9c-460e-8a1e-7a9bdf12defc.png">

