### PR TITLE
Hotfix/4.5.1

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -71,7 +71,7 @@ class SimpleHtml extends PureComponent {
         const nodeStyle = cssStringToObject(styleAttrib);
         const source = _.get(firstChild, 'attribs.src', '');
 
-        const resolvedNodeStyle = !isValidVideoFormat(source)
+        const resolvedNodeStyle = isValidVideoFormat(source)
           ? _.omit(nodeStyle, ['height', 'padding-bottom'])
           : nodeStyle;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
- adjust conditioning for `figure` styling when child element is `iframe`
  -  use case for this is Shoutem Builder rich text editor, which puts videos and images into `figure` parent tag