### PR TITLE
Use outerPadding style prop to resolve maxWidth

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -220,7 +220,12 @@ class SimpleHtml extends PureComponent {
   render() {
     const { style, body, customTagStyles, ...otherProps } = this.props;
 
-    const paddingValue = _.get(style, 'container.paddingLeft') * 2;
+    // parentContainerPadding - padding between screen & SimpleHtml. Parent container
+    // can have it's own padding. If it does, we have to include it in calculation,
+    // otherwise maxWidth will be more than max & images will go over the edge
+    const parentContainerPadding = style.outerPadding || 0;
+    const paddingValue =
+      _.get(style, 'container.paddingLeft') * 2 + parentContainerPadding;
     const maxWidth = Dimensions.get('window').width - paddingValue;
 
     const tagStyles = {


### PR DESCRIPTION
Before, we've forgotten to add `SimpleHtml` parent container padding into our `maxWidth` calculation.
This solves it.

Now, when calling `<SimpleHtml />`, we'll have to pass `style.outerPadding` prop to resolve this calculation properly.

**Before:**
![Screenshot 2021-09-01 at 16 32 46](https://user-images.githubusercontent.com/57353746/131692643-c4335758-9738-4235-9e86-f7d13a0e5e5a.png)


**Now:**
![Screenshot 2021-09-01 at 16 32 26](https://user-images.githubusercontent.com/57353746/131692676-efebacbf-5d40-4c46-b39f-14bac6db1ba4.png)
