### PR TITLE
feature/SEEXT-10408 Create SimpleHtml's prop for declaring custom alterNode function

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -62,7 +62,15 @@ class SimpleHtml extends PureComponent {
     const styleAttrib = _.get(node, 'attribs.style', '').trim();
 
     if (customAlterNode && _.isFunction(customAlterNode)) {
-      return customAlterNode(node, cssObjectToString, cssStringToObject);
+      const resolvedNode = customAlterNode(
+        node,
+        cssObjectToString,
+        cssStringToObject,
+      );
+
+      if (resolvedNode) {
+        return resolvedNode;
+      }
     }
 
     if (node.name === 'table') {

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -33,6 +33,7 @@ class SimpleHtml extends PureComponent {
     customTagStyles: PropTypes.object,
     customHandleLinkPress: PropTypes.func,
     unsupportedVideoFormatMessage: PropTypes.string,
+    customAlterNode: PropTypes.func,
   };
 
   constructor(props) {
@@ -56,9 +57,13 @@ class SimpleHtml extends PureComponent {
    * video iframe tags in when video format is unsupported
    */
   alterNode(node) {
-    const { style } = this.props;
+    const { customAlterNode, style } = this.props;
 
     const styleAttrib = _.get(node, 'attribs.style', '').trim();
+
+    if (customAlterNode && _.isFunction(customAlterNode)) {
+      return customAlterNode(node, cssObjectToString, cssStringToObject);
+    }
 
     if (node.name === 'table') {
       return tableAlterNode(node);


### PR DESCRIPTION
This should enable us to alter nodes from outside of `SimpleHtml`, from a component rendering `SimpleHtml`, making our life easier & keeping custom logic outside `@shoutem/ui`.

**Before, no alterations:**
![Screenshot 2021-09-07 at 09 20 13](https://user-images.githubusercontent.com/57353746/132302545-619839f7-6b91-46f3-bfa6-986f9016a286.png)


Example code for altering `div` node with `unsplash-image-container` ID, defined in `AboutScreen.js`:

```
  alterUnsplashImagesNode(node) {
    const styleAttrib = _.get(node, 'attribs.style', '').trim();

    if (node.attribs?.id === 'unsplash-image-container') {
      const imageContainerWithMargins = {
        attribs: {
          style: `${styleAttrib}margin-top: 115px; margin-bottom: 130px;`,
        },
      };
      const resolvedNode = _.merge(node, imageContainerWithMargins);
      return resolvedNode;
    }

    return null;
  }

  renderInfo(profile) {
    if (!_.get(profile, 'info')) {
      return null;
    }

    return (
      <SimpleHtml
        body={profile?.info}
        customAlterNode={this.alterUnsplashImagesNode}
      />
    );
  }
```

**After, with `customAlterNode`, adding margins:**
![Screenshot 2021-09-07 at 09 19 50](https://user-images.githubusercontent.com/57353746/132302600-375890fa-e77b-4653-bea2-fcf346dfb62e.png)
