### PR TITLE
Adjust paddingValue calculation in alterNode fn

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -87,7 +87,12 @@ class SimpleHtml extends PureComponent {
       return false;
     }
 
-    const paddingValue = _.get(style, 'container.paddingLeft') * 2;
+    // parentContainerPadding - padding between screen & SimpleHtml. Parent container
+    // can have it's own padding. If it does, we have to include it in calculation,
+    // otherwise maxWidth will be more than max & images will go over the edge
+    const parentContainerPadding = style.outerPadding || 0;
+    const paddingValue =
+      _.get(style, 'container.paddingLeft') * 2 + parentContainerPadding;
     const maxWidth = Dimensions.get('window').width - paddingValue;
     const nodeHeight = _.get(node, 'attribus.height');
     const nodeRatio = nodeWidth / nodeHeight;


### PR DESCRIPTION
Missed it in original PR.
The same calculation adjustment was done in `render()` function.