### PR TITLE
Feature/seext 10469 adjust drop downs horizontal style to have new theme properties background & text colors 

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -2089,6 +2089,8 @@ export default (variables = defaultThemeVariables) => ({
     '.navBar': {
       horizontalContainer: {
         backgroundColor: variables.navBarBackground,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderColor: variables.navBarBorderColor,
         minHeight: 40,
         maxHeight: 200,
         justifyContent: 'center',

--- a/theme.js
+++ b/theme.js
@@ -2100,7 +2100,7 @@ export default (variables = defaultThemeVariables) => ({
 
       selectedOption: {
         'shoutem.ui.Icon': {
-          color: variables.navBarIconsColor,
+          color: variables.navBarText.color,
         },
         'shoutem.ui.Text': {
           ...variables.navBarText,
@@ -2111,7 +2111,7 @@ export default (variables = defaultThemeVariables) => ({
           ),
           fontWeight: resolveFontWeight('normal'),
           fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
-          color: variables.navBarIconsColor,
+          color: variables.navBarText.color,
         },
       },
     },

--- a/theme.js
+++ b/theme.js
@@ -2087,6 +2087,15 @@ export default (variables = defaultThemeVariables) => ({
     },
 
     '.navBar': {
+      horizontalContainer: {
+        backgroundColor: variables.navBarBackground,
+        minHeight: 40,
+        maxHeight: 200,
+        justifyContent: 'center',
+        width: window.width,
+        marginTop: 0,
+      },
+
       selectedOption: {
         'shoutem.ui.Icon': {
           color: variables.navBarIconsColor,

--- a/theme.js
+++ b/theme.js
@@ -2041,10 +2041,9 @@ export default (variables = defaultThemeVariables) => ({
         minHeight: 40,
         maxHeight: 200,
         justifyContent: 'center',
-        backgroundColor: inverseColorBrightnessForAmount(
-          variables.paperColor,
-          5,
-        ),
+        backgroundColor:
+          variables.categoryDropdownBackgroundColor ||
+          inverseColorBrightnessForAmount(variables.paperColor, 5),
         width: window.width,
         marginTop: 0,
         borderBottomWidth: StyleSheet.hairlineWidth,
@@ -2052,7 +2051,7 @@ export default (variables = defaultThemeVariables) => ({
       },
       selectedOption: {
         'shoutem.ui.Icon': {
-          color: variables.text.color,
+          color: variables.categoryDropdownTextColor || variables.text.color,
         },
         'shoutem.ui.Text': {
           ...variables.navBarText,
@@ -2061,7 +2060,7 @@ export default (variables = defaultThemeVariables) => ({
             'normal',
             variables.navBarText.fontStyle,
           ),
-          color: variables.text.color,
+          color: variables.categoryDropdownTextColor || variables.text.color,
           fontWeight: resolveFontWeight('normal'),
           fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
           textAlign: 'center',
@@ -2087,20 +2086,9 @@ export default (variables = defaultThemeVariables) => ({
     },
 
     '.navBar': {
-      horizontalContainer: {
-        backgroundColor: variables.navBarBackground,
-        borderBottomWidth: StyleSheet.hairlineWidth,
-        borderColor: variables.navBarBorderColor,
-        minHeight: 40,
-        maxHeight: 200,
-        justifyContent: 'center',
-        width: window.width,
-        marginTop: 0,
-      },
-
       selectedOption: {
         'shoutem.ui.Icon': {
-          color: variables.navBarText.color,
+          color: variables.navBarIconsColor,
         },
         'shoutem.ui.Text': {
           ...variables.navBarText,
@@ -2111,7 +2099,7 @@ export default (variables = defaultThemeVariables) => ({
           ),
           fontWeight: resolveFontWeight('normal'),
           fontStyle: resolveFontStyle(variables.navBarText.fontStyle),
-          color: variables.navBarText.color,
+          color: variables.navBarIconsColor,
         },
       },
     },


### PR DESCRIPTION
Adjusted the background color & text color of dropdown for `horizontal` style.
`Prime` was the only theme that had "weird" colors for dropdown.

Default dropdown color values for each theme:
![Prime](https://user-images.githubusercontent.com/57353746/134372935-e102ff72-2347-420f-a5a8-4ebc2b0dd802.png)
![Rose](https://user-images.githubusercontent.com/57353746/134372939-7c670877-00cd-4ec9-9b37-2a1134115f87.png)
![Bleu](https://user-images.githubusercontent.com/57353746/134372924-021e64d9-bd32-492f-aea5-205e4ae49862.png)
![Noir](https://user-images.githubusercontent.com/57353746/134372929-0cda57cb-7bde-417a-a48b-40bac1ab0680.png)


Prime, after adjusting new dropdown theme properties:
![Prime after](https://user-images.githubusercontent.com/57353746/134373002-a0d02115-cdef-494c-abac-8482bb950791.png)


