### PR TITLE
Prevent loadMore() exec if user is not scrolling

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -77,6 +77,7 @@ class ListView extends PureComponent {
 
     this.state = {
       status: props.loading ? Status.LOADING : Status.IDLE,
+      isScrolling: false,
     };
   }
 
@@ -196,17 +197,21 @@ class ListView extends PureComponent {
     // reference
     mappedProps.ref = this.handleListViewRef;
 
+    mappedProps.onMomentumScrollBegin = this.setIsScrolling(true);
+    
+    mappedProps.onMomentumScrollEnd = this.setIsScrolling(false);
+
     return mappedProps;
   }
 
   // eslint-disable-next-line consistent-return
   createOnLoadMore() {
     const { onLoadMore, data } = this.props;
-    const { status } = this.state;
+    const { isScrolling, status } = this.state;
     if (onLoadMore) {
       return _.throttle(
         () => {
-          if (!_.isEmpty(data) && status === Status.IDLE) {
+          if (!_.isEmpty(data) && isScrolling && status === Status.IDLE) {
             onLoadMore();
           }
         },
@@ -214,6 +219,10 @@ class ListView extends PureComponent {
         { leading: true },
       );
     }
+  }
+
+  setIsScrolling(isScrolling) {
+    this.setState({ isScrolling });
   }
 
   autoHideHeader({


### PR DESCRIPTION
`ListView` was calling `loadMore()` when the layout was full size & then resized to have less than screen height, even tho user wasn't scrolling.
Fixed that bad boy by adding `isScrolling` check.

Before (load more is triggered when user types in 'A12'):
https://user-images.githubusercontent.com/57353746/134509555-56f020cc-7efc-49da-9ea4-d3d791f45fdc.mov


Now:
https://user-images.githubusercontent.com/57353746/134509572-7465d448-132b-4d9c-b45a-30aa3fb816c3.mov


