### PR TITLE
Fix momentum fn calls

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -197,9 +197,9 @@ class ListView extends PureComponent {
     // reference
     mappedProps.ref = this.handleListViewRef;
 
-    mappedProps.onMomentumScrollBegin = () => this.setIsScrolling(true);
+    mappedProps.onMomentumScrollBegin = this.setStartedScrolling;
 
-    mappedProps.onMomentumScrollEnd = () => this.setIsScrolling(false);
+    mappedProps.onMomentumScrollEnd = this.setEndedScrolling;
 
     return mappedProps;
   }
@@ -221,8 +221,12 @@ class ListView extends PureComponent {
     }
   }
 
-  setIsScrolling(isScrolling) {
-    this.setState({ isScrolling });
+  setStartedScrolling() {
+    this.setState({ isScrolling: true });
+  }
+
+  setEndedScrolling() {
+    this.setState({ isScrolling: true });
   }
 
   autoHideHeader({


### PR DESCRIPTION
ListView was never calling loadMore().
onMomentScrollBegin & End wasn't firing - `isScrolling` was never set to true
https://user-images.githubusercontent.com/57353746/136371146-75c91bf3-013a-46fe-abc4-c671b4bcc552.mov

