### PR TITLE
Feature/seext 10512 photos from rss feeds are enlarged in the app

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -128,7 +128,7 @@ class SimpleHtml extends PureComponent {
       return false;
     }
 
-    const nodeHeight = _.get(node, 'attribus.height');
+    const nodeHeight = node.attribus?.height;
     const nodeDimensions = { width: nodeWidth, height: nodeHeight };
     const { width, height } = resolveDimensions(nodeDimensions, style);
 


### PR DESCRIPTION
Photos were "enlarged" because of 2 issues:
- we have defined `maxImagesWidth` that should allow `SimpleHtml` to resize images out of the box. But, we also have custom renderer defined for attachments - `renderAttachments`. We manually set image's height there & not defining width. Custom renderer automatically ignores/overrides `SimpleHtml's` default config - `maxImagesSize` 
- we weren't properly calculating ratio in image resize calculation

I've moved dimensions calculations out of the class & re-used it inside the class.
Added some code improvements - changed fallback for node.width from `false` to `undefined`.

Tested everything, seems OK.

Check screenshots, on the left hand side - we have state before.
Right hand side (yes, you guessed it!) - fixed state of images.

![Screenshot 2021-10-21 at 12 10 44](https://user-images.githubusercontent.com/57353746/138262443-3fbed225-4053-46e2-bb40-d23ab09f6316.png)
![Screenshot 2021-10-21 at 12 10 27](https://user-images.githubusercontent.com/57353746/138262448-3233c3a1-b284-4035-af4f-957bd9880a16.png)
![Screenshot 2021-10-21 at 12 11 09](https://user-images.githubusercontent.com/57353746/138262425-f3c554e8-dba1-42a6-ada3-ff28dfba565f.png)

