### PR TITLE
Update DateTimePicker

### DIFF
--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -13,12 +13,16 @@ import { View } from './View';
 
 const isIos = Platform.OS === 'ios';
 
-const MODES = { DATE: 'date', DATETIME: 'datetime', TIME: 'time' };
+export const DATEPICKER_MODES = {
+  DATE: 'date',
+  DATETIME: 'datetime',
+  TIME: 'time',
+};
 
 const DISPLAY_MODES = {
-  [MODES.DATE]: 'inline',
-  [MODES.DATETIME]: 'inline',
-  [MODES.TIME]: 'spinner',
+  [DATEPICKER_MODES.DATE]: 'inline',
+  [DATEPICKER_MODES.DATETIME]: 'inline',
+  [DATEPICKER_MODES.TIME]: 'spinner',
 };
 
 function getDisplayMode(mode) {
@@ -46,7 +50,6 @@ class DateTimePicker extends PureComponent {
   }
 
   componentDidUpdate() {
-    // todo: check why set state here
     if (!isIos) {
       const { value } = this.props;
 
@@ -65,7 +68,7 @@ class DateTimePicker extends PureComponent {
 
     const { mode, onValueChanged } = this.props;
 
-    const showTimePicker = mode === MODES.DATETIME;
+    const showTimePicker = mode === DATEPICKER_MODES.DATETIME;
 
     this.setState({ value, showPicker: false, showTimePicker });
     return !showTimePicker && onValueChanged(value);
@@ -206,7 +209,7 @@ DateTimePicker.propTypes = {
   cancelButtonText: PropTypes.string,
   confirmButtonText: PropTypes.string,
   is24Hour: PropTypes.bool,
-  mode: PropTypes.oneOf(Object.values(MODES)),
+  mode: PropTypes.oneOf(Object.values(DATEPICKER_MODES)),
   onValueChanged: PropTypes.func,
   textValue: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),

--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -139,7 +139,7 @@ class DateTimePicker extends PureComponent {
         >
           <Icon name="drop-down" style={style.icon} />
         </TouchableOpacity>
-        {isIos && (
+        {isIos && showPicker && (
           <Modal
             backdropOpacity={0.5}
             isVisible={showPicker}


### PR DESCRIPTION
Updated DateTimePicker component with following: 
(screenshots below)
- added `Cancel` button to iOS modal (Android modal has it by default, so it made sense to add it since modal has no "clear" way of dismissing - other than swipe)
- added better handling for `date` and `datetime` display mode on iOS
- added `datetime` ability on Android: first open date modal, and after open time modal

<table>
<tr>
<td>
<img width="500" src="https://user-images.githubusercontent.com/38048916/140712700-a1820a1d-6395-4a86-8210-2a76a12f5d5c.png">
</td>
<td>
<img width="500" src="https://user-images.githubusercontent.com/38048916/140712704-bb95a430-d9da-43c9-8d1f-4fe8b4ceabc1.png">
</td>
<td>
<img width="500" src="https://user-images.githubusercontent.com/38048916/140712707-9453182d-e154-4083-844f-fe4d9ca94bb9.png">
</td>
</tr>
<tr>
<td>
<img width="500" src="https://user-images.githubusercontent.com/38048916/140712942-69140f8a-906e-497d-9949-1726a9db897f.png">
</td>
<td>
<img width="500" src="https://user-images.githubusercontent.com/38048916/140712949-a5d02495-aab4-4d89-b79a-4c3a67143fc4.png">
</td>
</tr>
 </table>