### PR TITLE
Remove lifecycle because it breaks component functionality

### DIFF
--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -49,14 +49,6 @@ class DateTimePicker extends PureComponent {
     };
   }
 
-  componentDidUpdate() {
-    if (!isIos) {
-      const { value } = this.props;
-
-      this.setState({ value });
-    }
-  }
-
   handleValueChanged(event, value) {
     if (isIos) {
       return this.setState({ value });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.6.6-rc.0",
+  "version": "4.6.6-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.6.6-rc.0",
+  "version": "4.6.6-rc.1",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
`componentDidUpdate` was added for whatever reason that I can't think of. Maybe because of specific bug that was related to iOS selected theme - something didn't work if user had dark theme.

However, now that we support date & time, it breaks functionality

Once the date is selected, it's saved to component's state.
We then set  `showTimePicker` to true, forcing re-render & componentDidUpdate. 
Datetime value is again set to whatever the value parent component is sending via props, thus resetting the date part of the value.

Everything seems to work fine after this update, iOS & Android