### PR TITLE
Remove isScrolling condition for load more items trigger

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -57,7 +57,6 @@ class ListView extends PureComponent {
 
     this.state = {
       status: props.loading ? Status.LOADING : Status.IDLE,
-      isScrolling: false,
     };
   }
 
@@ -177,21 +176,17 @@ class ListView extends PureComponent {
     // reference
     mappedProps.ref = this.handleListViewRef;
 
-    mappedProps.onMomentumScrollBegin = this.setStartedScrolling;
-
-    mappedProps.onMomentumScrollEnd = this.setEndedScrolling;
-
     return mappedProps;
   }
 
   // eslint-disable-next-line consistent-return
   createOnLoadMore() {
     const { onLoadMore, data } = this.props;
-    const { isScrolling, status } = this.state;
+    const {  status } = this.state;
     if (onLoadMore) {
       return _.throttle(
         () => {
-          if (!_.isEmpty(data) && isScrolling && status === Status.IDLE) {
+          if (!_.isEmpty(data)  && status === Status.IDLE) {
             onLoadMore();
           }
         },
@@ -199,14 +194,6 @@ class ListView extends PureComponent {
         { leading: true },
       );
     }
-  }
-
-  setStartedScrolling() {
-    this.setState({ isScrolling: true });
-  }
-
-  setEndedScrolling() {
-    this.setState({ isScrolling: true });
   }
 
   autoHideHeader({

--- a/components/ListView.js
+++ b/components/ListView.js
@@ -182,11 +182,11 @@ class ListView extends PureComponent {
   // eslint-disable-next-line consistent-return
   createOnLoadMore() {
     const { onLoadMore, data } = this.props;
-    const {  status } = this.state;
+    const { status } = this.state;
     if (onLoadMore) {
       return _.throttle(
         () => {
-          if (!_.isEmpty(data)  && status === Status.IDLE) {
+          if (!_.isEmpty(data) && status === Status.IDLE) {
             onLoadMore();
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I've introduced current bug when I was trying to fix issue from : https://github.com/shoutem/ui/pull/642, and in that PR, I was trying to fix wrong bug.
The bug was on backend side, where search results result would have next link of whole collection, instead of its own-null.
List was triggering load more when BE returned 2 items only - but that's actually how FlatList SHOULD and does work.

At that moment, I've prevented it by introducing `isScrolling` - which now blocks load more when list height is approx screen height. End threshold will be reached before isScrolling will be set to true (load more fn is called if isScrolling is true only), or isScrolling won't be set to true if user holds the list and moves (doesn't let press go like on scroll)


I'm reverting isScrolling logic, allowing FlatList to do its job. load more will be triggered right away, because end threshold is reached from the first time list renders.
**Video 1**

Backend part of the bug was fixed few months ago, so we're good here.
**Video 2**


Video 1
https://user-images.githubusercontent.com/57353746/155283835-aaf7760d-00b1-413d-9e3b-a359bbf4cd86.mov

<br><br><br><br>
Video 2

https://user-images.githubusercontent.com/57353746/155283879-b01add17-2b00-435a-8338-c001840ec505.mov


