### PR TITLE
Fix cyclic dependency in keyboard helper, cleanup index

### DIFF
--- a/const.js
+++ b/const.js
@@ -1,3 +1,6 @@
+const { Platform, StatusBar } = require('react-native');
+const { Device } = require('./helpers');
+
 const IPHONE_X_HOME_INDICATOR_PADDING = 34;
 const IPHONE_X_LONG_SIDE = 812;
 const IPHONE_X_NOTCH_PADDING = 30;
@@ -10,6 +13,15 @@ const IPHONE_12_MAX_LONG_SIDE = 926;
 
 const NAVIGATION_HEADER_HEIGHT = 64;
 
+const STATUS_BAR_OFFSET =
+  Platform.OS === 'android' ? -StatusBar.currentConfig : 0;
+const NAVIGATION_BAR_HEIGHT = Device.select({
+  iPhoneX: NAVIGATION_HEADER_HEIGHT + IPHONE_X_NOTCH_PADDING,
+  iPhoneXR: NAVIGATION_HEADER_HEIGHT + IPHONE_XR_NOTCH_PADDING,
+  notchedAndroid: NAVIGATION_HEADER_HEIGHT + StatusBar.currentHeight,
+  default: NAVIGATION_HEADER_HEIGHT,
+});
+
 module.exports = {
   IPHONE_X_HOME_INDICATOR_PADDING,
   IPHONE_X_LONG_SIDE,
@@ -18,5 +30,7 @@ module.exports = {
   IPHONE_XR_NOTCH_PADDING,
   IPHONE_12_LONG_SIDE,
   IPHONE_12_MAX_LONG_SIDE,
+  NAVIGATION_BAR_HEIGHT,
   NAVIGATION_HEADER_HEIGHT,
+  STATUS_BAR_OFFSET,
 };

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,4 +1,2 @@
-import { Device } from './device-selector';
-import Keyboard from './keyboard';
-
-export { Device, Keyboard };
+export { Device } from './device-selector';
+export { calculateKeyboardOffset, default as Keyboard } from './keyboard';

--- a/helpers/keyboard.js
+++ b/helpers/keyboard.js
@@ -1,5 +1,5 @@
 import { Platform, StatusBar } from 'react-native';
-import { NAVIGATION_BAR_HEIGHT } from '../theme';
+import { NAVIGATION_BAR_HEIGHT } from '../const';
 
 export function calculateKeyboardOffset(extraOffset = 0) {
   const resolvedOffset = NAVIGATION_BAR_HEIGHT + extraOffset;
@@ -11,4 +11,8 @@ export function calculateKeyboardOffset(extraOffset = 0) {
   return StatusBar.currentHeight + resolvedOffset;
 }
 
+// TODO: Deprecate and remove Keyboard.calculateKeyboardOffset
+// Replace with direct function call. It's cleaner for any practical use of this
+// because we will usually import Keyboard from react-native alongside this, so
+// we're forced to rename imports.
 export default { calculateKeyboardOffset };

--- a/index.js
+++ b/index.js
@@ -1,90 +1,83 @@
 import { setDefaultThemeStyle } from './init';
 import getTheme, {
+  calculateLineHeight,
   defaultThemeVariables,
   dimensionRelativeToIphone,
-  calculateLineHeight,
   resolveFontFamily,
-  resolveFontWeight,
   resolveFontStyle,
+  resolveFontWeight,
 } from './theme';
 
 setDefaultThemeStyle();
 
 // Theme
 export {
-  getTheme,
+  calculateLineHeight,
   defaultThemeVariables,
   dimensionRelativeToIphone,
-  calculateLineHeight,
+  getTheme,
   resolveFontFamily,
-  resolveFontWeight,
   resolveFontStyle,
+  resolveFontWeight,
 };
 
 // Components
 export { ActionSheet } from './components/ActionSheet';
-export { View } from './components/View';
-export { Screen } from './components/Screen';
-
-export { NavigationBar } from './components/NavigationBar';
-export { NavigationBarAnimations } from './components/NavigationBar/NavigationBarAnimations';
-export { DropDownMenu, DropDownModal } from './components/DropDownMenu';
-export { Overlay } from './components/Overlay';
-
-export { ScrollView } from './components/ScrollView';
-export { ListView } from './components/ListView';
-export { GridRow } from './components/GridRow';
-
-export { TouchableOpacity } from './components/TouchableOpacity';
-export { TouchableNativeFeedback } from './components/TouchableNativeFeedback';
-export { Touchable } from './components/Touchable';
 export { Button } from './components/Button';
-export { Icon, registerIcons } from './components/Icon';
-
+export { Card } from './components/Card';
+export { DateTimePicker } from './components/DateTimePicker';
+export { Divider } from './components/Divider';
+export { DropDownMenu, DropDownModal } from './components/DropDownMenu';
+export { EmptyListImage } from './components/EmptyListImage';
+export { EmptyStateView } from './components/EmptyStateView';
 export { FormGroup } from './components/FormGroup';
-export { TextInput } from './components/TextInput';
-
-export { Spinner } from './components/Spinner';
-export { Switch } from './components/Switch';
-
-export { Video } from './components/Video';
+export { GridRow } from './components/GridRow';
+export { HorizontalPager } from './components/HorizontalPager';
+export { Icon, registerIcons } from './components/Icon';
 export { Image } from './components/Image';
 export { ImageBackground } from './components/ImageBackground';
-export { ImagePreview } from './components/ImagePreview';
 export { ImageGallery } from './components/ImageGallery';
-export { InlineGallery } from './components/InlineGallery';
 export { ImageGalleryOverlay } from './components/ImageGalleryOverlay';
-export { HorizontalPager } from './components/HorizontalPager';
-export { LoadingIndicator } from './components/LoadingIndicator';
-export { PageIndicators } from './components/PageIndicators';
-export { Html } from './html';
-export { SimpleHtml } from './html';
-export { ShareButton } from './components/ShareButton';
-export { LinearGradient } from './components/LinearGradient';
-
-export { Heading, Title, Subtitle, Text, Caption } from './components/Text';
-
-export { Divider } from './components/Divider';
-
-export { Card } from './components/Card';
-export { Row } from './components/Row';
-export { Tile } from './components/Tile';
-
-export { Lightbox } from './components/Lightbox';
-
+export { ImagePreview } from './components/ImagePreview';
 export { InlineDropDownMenu } from './components/InlineDropDownMenu';
-export { EmptyStateView } from './components/EmptyStateView';
-export { EmptyListImage } from './components/EmptyListImage';
-export { NumberInput } from './components/NumberInput';
-export { SearchField } from './components/SearchField';
-export { TabMenu } from './components/TabMenu';
-export { YearRangePicker } from './components/YearRangePicker';
-export { DateTimePicker } from './components/DateTimePicker';
+export { InlineGallery } from './components/InlineGallery';
+export { Lightbox } from './components/Lightbox';
+export { LinearGradient } from './components/LinearGradient';
+export { ListView } from './components/ListView';
 export { LoadingContainer } from './components/LoadingContainer';
+export { LoadingIndicator } from './components/LoadingIndicator';
+export { NavigationBar } from './components/NavigationBar';
+export { NavigationBarAnimations } from './components/NavigationBar/NavigationBarAnimations';
+export { NumberInput } from './components/NumberInput';
+export { Overlay } from './components/Overlay';
+export { PageIndicators } from './components/PageIndicators';
+export { Row } from './components/Row';
+export { Screen } from './components/Screen';
+export { ScrollView } from './components/ScrollView';
+export { SearchField } from './components/SearchField';
+export { ShareButton } from './components/ShareButton';
+export { Spinner } from './components/Spinner';
+export { Switch } from './components/Switch';
+export { TabMenu } from './components/TabMenu';
+export { Caption, Heading, Subtitle, Text, Title } from './components/Text';
+export { TextInput } from './components/TextInput';
+export { Tile } from './components/Tile';
+export { Touchable } from './components/Touchable';
+export { TouchableNativeFeedback } from './components/TouchableNativeFeedback';
+export { TouchableOpacity } from './components/TouchableOpacity';
+export { Video } from './components/Video';
+export { View } from './components/View';
+export { YearRangePicker } from './components/YearRangePicker';
 
+// Examples
 export { Examples } from './examples/components';
 
-export { Device, Keyboard } from './helpers';
+// Helpers
+export { calculateKeyboardOffset, Device, Keyboard } from './helpers';
+
+// HTML
+export { Html } from './html';
+export { SimpleHtml } from './html';
 
 // Constants
 export {
@@ -94,5 +87,7 @@ export {
   IPHONE_XR_LONG_SIDE,
   IPHONE_XR_NOTCH_PADDING,
   nativeDependencies,
+  NAVIGATION_BAR_HEIGHT,
   NAVIGATION_HEADER_HEIGHT,
+  STATUS_BAR_OFFSET,
 } from './const';

--- a/theme.js
+++ b/theme.js
@@ -11,20 +11,13 @@ import {
   IPHONE_X_HOME_INDICATOR_PADDING,
   IPHONE_X_NOTCH_PADDING,
   IPHONE_XR_NOTCH_PADDING,
+  NAVIGATION_BAR_HEIGHT,
   NAVIGATION_HEADER_HEIGHT,
+  STATUS_BAR_OFFSET,
 } from './const';
 import { Device } from './helpers';
 
 const window = Dimensions.get('window');
-
-const STATUS_BAR_OFFSET =
-  Platform.OS === 'android' ? -StatusBar.currentConfig : 0;
-export const NAVIGATION_BAR_HEIGHT = Device.select({
-  iPhoneX: NAVIGATION_HEADER_HEIGHT + IPHONE_X_NOTCH_PADDING,
-  iPhoneXR: NAVIGATION_HEADER_HEIGHT + IPHONE_XR_NOTCH_PADDING,
-  notchedAndroid: NAVIGATION_HEADER_HEIGHT + StatusBar.currentHeight,
-  default: NAVIGATION_HEADER_HEIGHT,
-});
 
 export const sizeVariants = [
   '',


### PR DESCRIPTION
`keyboard.js` was importing something from `theme.js`, while also being imported into `theme.js`. No bueno.