### PR TITLE
Remove custom keyExtractor default logic

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -152,11 +152,6 @@ class ListView extends PureComponent {
     // data to display
     mappedProps.data = data;
 
-    // key extractor
-    if (!keyExtractor) {
-      mappedProps.keyExtractor = (item, index) => index.toString();
-    }
-
     // sections for SectionList
     if (sections) {
       mappedProps.sections = sections;


### PR DESCRIPTION
Removed our fallback **keyExtractor** logic because it was causing a bug.

React Native's **FlatList** handles default keyExtractor much better.
https://reactnative.dev/docs/flatlist#keyextractor

This change is backwards compatible because FlatList fallbacks to item index as keyExtractor, but as last possible option.


**Bug example:**
- FlatList is rendered, this is the first item in the list (image below). It has index:0 & its keyExtractor is 0 at the moment.
![Screenshot 2022-04-26 at 13 30 20](https://user-images.githubusercontent.com/57353746/165290647-82648ff7-dbe9-4332-904a-fac1d6e4438d.png)
<br><br>
- we create new status, with **only text** (_123_), no attachments or URL
- new post is now at index/keyExtractor 0 -> it renders right status message, but gets cached attachment component, from previous item[0]

Newly created status item has proper text, but gets attachment from previous item - that was at index 0 before.
![Screenshot 2022-04-26 at 13 30 13](https://user-images.githubusercontent.com/57353746/165291606-6aaeb166-7392-4162-a946-2cc3bba253eb.png)



This probably only occurs in this specific case because we render list first, then render item's attachment components, after they're calculated (attachments are calculated using status text - parsing URL and fetching metadata for that URL, that specifies attachment component props).