### PR TITLE
Enable Android fullscreen Vimeo play (bug fixed)

### DIFF
--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -64,16 +64,9 @@ class Video extends PureComponent {
   render() {
     const { width, height, style, poster } = this.props;
 
-    // https://github.com/vimeo/player.js/issues/514
-    // Vimeo player crashes the app, if played in full screen portrait mode and if user
-    // tries to navigate back using Android hardware back button. Disableing full screen
-    // option for Vimeo until their player is fixed.
-    const isYoutubeVideo = this.sourceReader.isYouTube;
-
     return (
       <View style={style.container}>
         <WebView
-          allowsFullscreenVideo={isYoutubeVideo}
           mediaPlaybackRequiresUserAction={false}
           style={{ width, height }}
           source={getSource(this.sourceReader, poster)}

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -67,6 +67,7 @@ class Video extends PureComponent {
     return (
       <View style={style.container}>
         <WebView
+          allowsFullscreenVideo
           mediaPlaybackRequiresUserAction={false}
           style={{ width, height }}
           source={getSource(this.sourceReader, poster)}


### PR DESCRIPTION
Works perfectly fine now, tested on older Android devices with hardware back button & newer devices without it.
Tried all possible back navigation actions - hardware button, soft back button, swipe etc., in both video rotations, works flawlessly now.