### PR TITLE
Fix style resolution

### DIFF
--- a/components/ScrollView/ScrollView.js
+++ b/components/ScrollView/ScrollView.js
@@ -79,7 +79,7 @@ class ScrollView extends PureComponent {
   render() {
     const { style, ...otherProps } = this.props;
     const { scrollViewProps } = this.animationDriver;
-    const { contentContainerStyle, ...otherStyle } = style;
+    const { contentContainerStyle = {}, ...otherStyle } = style;
 
     return (
       <Animated.ScrollView


### PR DESCRIPTION
We gotta have fallback for `contentContainerStyle`, otherwise ScrollViews will crash the app