### PR TITLE
Update to `deprecated-react-native-prop-types`

### DIFF
--- a/components/EmptyListImage.js
+++ b/components/EmptyListImage.js
@@ -52,7 +52,6 @@ class EmptyListImage extends PureComponent {
 }
 
 EmptyListImage.propTypes = {
-  ...EmptyListImage.propTypes,
   image: PropTypes.func,
   imageStyle: PropTypes.object,
   message: PropTypes.string,

--- a/components/GridRow.js
+++ b/components/GridRow.js
@@ -1,5 +1,5 @@
 import React, { Children, PureComponent } from 'react';
-import { View as RNView, ViewPropTypes } from 'react-native';
+import { View as RNView } from 'react-native';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { connectAnimation } from '@shoutem/animation';
@@ -35,7 +35,7 @@ class GridRow extends PureComponent {
 }
 
 GridRow.propTypes = {
-  ...ViewPropTypes,
+  ...View.propTypes,
   columns: PropTypes.number.isRequired,
 };
 

--- a/components/Image.js
+++ b/components/Image.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Image as RNImage, Platform } from 'react-native';
 import autoBindReact from 'auto-bind/react';
+import { ImagePropTypes } from 'deprecated-react-native-prop-types';
 import _ from 'lodash';
 import { connectAnimation } from '@shoutem/animation';
 import { connectStyle } from '@shoutem/theme';
@@ -82,7 +83,7 @@ class Image extends PureComponent {
 }
 
 Image.propTypes = {
-  ...RNImage.propTypes,
+  ...ImagePropTypes.propTypes,
 };
 
 const AnimatedImage = connectAnimation(Image);

--- a/components/Text.js
+++ b/components/Text.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Text as RNText } from 'react-native';
+import { TextPropTypes } from 'deprecated-react-native-prop-types';
 import { connectAnimation } from '@shoutem/animation';
 import { connectStyle } from '@shoutem/theme';
 
@@ -10,7 +11,7 @@ class Text extends PureComponent {
 }
 
 Text.propTypes = {
-  ...RNText.propTypes,
+  ...TextPropTypes.propTypes,
 };
 
 const AnimatedText = connectAnimation(Text);

--- a/components/TextInput.js
+++ b/components/TextInput.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { TextInput as RNTextInput } from 'react-native';
 import autoBindReact from 'auto-bind/react';
+import { TextInputPropTypes } from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 import { connectAnimation, Wiggle } from '@shoutem/animation';
 import { connectStyle } from '@shoutem/theme';
@@ -91,7 +92,7 @@ class TextInput extends PureComponent {
 }
 
 TextInput.propTypes = {
-  ...RNTextInput.propTypes,
+  ...TextInputPropTypes,
   style: PropTypes.object.isRequired,
   animate: PropTypes.bool,
   errorMessage: PropTypes.string,

--- a/components/View.js
+++ b/components/View.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { View as RNView, ViewPropTypes } from 'react-native';
+import { View as RNView } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import PropTypes from 'prop-types';
 import { connectAnimation } from '@shoutem/animation';
 import { connectStyle } from '@shoutem/theme';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "auto-bind": "4.0.0",
     "babel-plugin-transform-decorators-legacy": "1.3.5",
     "buffer": "5.6.0",
+    "deprecated-react-native-prop-types": "2.3.0",
     "events": "1.1.0",
     "fs-extra": "7.0.1",
     "html-entities": "1.3.1",


### PR DESCRIPTION
Feature adds `deprecated-react-native-prop-types` and updates all components affected.