### PR TITLE
Update ShareButton

### DIFF
--- a/components/ShareButton.js
+++ b/components/ShareButton.js
@@ -24,7 +24,13 @@ class ShareButton extends PureComponent {
   onShare() {
     const { title, message, url } = this.props;
 
-    Share.share({
+    if (!url) {
+      // eslint-disable-next-line no-console
+      console.warn('Share URL not specified.');
+      return null;
+    }
+
+    return Share.share({
       title,
       // URL property isn't supported on Android, so we are
       // including it as the message for now.

--- a/components/ShareButton.js
+++ b/components/ShareButton.js
@@ -24,12 +24,6 @@ class ShareButton extends PureComponent {
   onShare() {
     const { title, message, url } = this.props;
 
-    if (!url) {
-      // eslint-disable-next-line no-console
-      console.warn('Share URL not specified.');
-      return null;
-    }
-
     return Share.share({
       title,
       // URL property isn't supported on Android, so we are
@@ -40,7 +34,11 @@ class ShareButton extends PureComponent {
   }
 
   render() {
-    const { animationName, iconProps, ...otherProps } = this.props;
+    const { animationName, iconProps, url, ...otherProps } = this.props;
+
+    if (!url) {
+      return null;
+    }
 
     return (
       <Button onPress={this.onShare} {...otherProps}>


### PR DESCRIPTION
Feature updates `ShareButton` to properly handle case when no url is specified. 
Sharing with invalid url caused crashes on both platforms.