### PR TITLE
Fix gallery crash

### DIFF
--- a/components/ImageGallery.js
+++ b/components/ImageGallery.js
@@ -85,6 +85,7 @@ function ImageGallery({
     const transformImageProps = Image.getPropsTransformer();
     const imageProps = {
       source: { uri: image },
+      style: { ...style.image },
     };
     const transformedImageProps = _.isFunction(transformImageProps)
       ? transformImageProps(imageProps)

--- a/components/ImageGallery.js
+++ b/components/ImageGallery.js
@@ -85,7 +85,7 @@ function ImageGallery({
     const transformImageProps = Image.getPropsTransformer();
     const imageProps = {
       source: { uri: image },
-      style: { ...style.image },
+      style: style.image,
     };
     const transformedImageProps = _.isFunction(transformImageProps)
       ? transformImageProps(imageProps)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Feature fixes `ImageGallery` crash caused by `transformImageProps` expecting `style` as a prop.

Not sure if this should be handled here or on extensions side, since shoutem.application defines [image prop transformer](https://github.com/shoutem/extensions/blob/850c0854f5008072c3d4d00d36f7d179dc65f9b7/shoutem.application/app/services/resizeImageSource.js#L22) that causes the crash. 
It used to work properly since old component had defined `style: { flex: 1 }` here.