### PR TITLE
Add flex wrap to toast message

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -3182,7 +3182,7 @@ export default () => {
         fontWeight: resolveFontWeight('400'),
         lineHeight: 16,
         flex: 1,
-        flexWrap: "wrap",
+        flexWrap: 'wrap',
       },
       buttonContainer: {
         paddingHorizontal: responsiveWidth(12),

--- a/theme.js
+++ b/theme.js
@@ -3158,6 +3158,7 @@ export default () => {
         color: resolveVariable('toastMessageColor'),
       },
       textContainer: {
+        flex: 1,
         height: responsiveHeight(48),
         justifyContent: 'space-between',
       },
@@ -3180,6 +3181,8 @@ export default () => {
         ),
         fontWeight: resolveFontWeight('400'),
         lineHeight: 16,
+        flex: 1,
+        flexWrap: "wrap",
       },
       buttonContainer: {
         paddingHorizontal: responsiveWidth(12),


### PR DESCRIPTION
Feature fixes toast message not wrapping properly if text is too long.

<table>
<tr>
<td>
Before
</td>
<td>
After
</td>
</tr>
<tr>
<td>
<img height="700" src="https://user-images.githubusercontent.com/38048916/207816846-423d4daa-8fda-4d5f-bfb5-5bde02ecab45.png">
</td>
<td>
<img height="700" src="https://user-images.githubusercontent.com/38048916/207816861-64882087-74f5-41d0-a46a-8d0ccfb631de.png">
</td>
</tr>
 </table>
