### PR TITLE
Default to Rubik-Regular for fontName when resolving font family

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.1.1",
+  "version": "6.1.2-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.1.1",
+  "version": "6.1.2-rc.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -68,7 +68,7 @@ export function responsiveHeight(dimension, actualRefVal = window.height) {
 // 'fontWeight' and 'fontStyle' aren't always supplied for every component, so we're setting default
 // values of 'normal'.
 export function resolveFontFamily(
-  fontName,
+  fontName = 'Rubik-Regular',
   fontWeight = 'normal',
   fontStyle = 'normal',
 ) {


### PR DESCRIPTION
Apparently in Android Shoutem apps there are certain scenarios where `fontName` in theme variables isn't defined at first, this should resolve it for the initial load while it catches up as well as just save us some headaches elsewhere in the future.