### PR TITLE
Remove double gallery icon definition

### DIFF
--- a/components/Icon/assets/index.js
+++ b/components/Icon/assets/index.js
@@ -171,7 +171,6 @@ export const defaultConfig = [
   { name: 'forward', icon: forward },
   { name: 'gallery', icon: gallery },
   { name: 'friends', icon: friends },
-  { name: 'gallery', icon: gallery },
   { name: 'garbage-can', icon: garbageCan },
   { name: 'gift', icon: gift },
   { name: 'github', icon: github },


### PR DESCRIPTION
`gallery` icon was declared twice

![Screenshot 2023-11-30 at 11 26 15](https://github.com/shoutem/ui/assets/57353746/dacd69be-6c6e-4e43-a8c5-c1a8497fddf0)
