### PR TITLE
Feature/adjust with notch padding calculation

### DIFF
--- a/helpers/device-selector.js
+++ b/helpers/device-selector.js
@@ -1,5 +1,5 @@
 import { Dimensions, Platform, StatusBar } from 'react-native';
-import { hasNotch } from 'react-native-device-info';
+import DeviceInfo from 'react-native-device-info';
 import _ from 'lodash';
 
 const { OS, isPad, isTVOS } = Platform;
@@ -16,6 +16,10 @@ export const IPHONE_12_LONG_SIDE = 844;
 export const IPHONE_12_MAX_LONG_SIDE = 926;
 
 export const NAVIGATION_HEADER_HEIGHT = 64;
+
+// Identifiers
+// iPhone10,3, iPhone10,6 - X.... Ne može veće od ovoga jer iPhone 8+ ima 10,5
+// 11+
 
 const xDimensionsMatch =
   height === IPHONE_X_LONG_SIDE || width === IPHONE_X_LONG_SIDE;
@@ -37,7 +41,7 @@ const isIphoneXR =
   !isTVOS &&
   (xrDimensionsMatch || twelveDimensionsMatch || twelveMaxDimensionsMatch);
 
-const isNotchedAndroid = OS === 'android' && hasNotch();
+const isNotchedAndroid = OS === 'android' && DeviceInfo.hasNotch();
 
 /**
  * Receives settings for different devices
@@ -70,6 +74,52 @@ export const NAVIGATION_BAR_HEIGHT = select({
   notchedAndroid: NAVIGATION_HEADER_HEIGHT + StatusBar.currentHeight,
   default: NAVIGATION_HEADER_HEIGHT,
 });
+
+export const getHomeIndicatorPadding = () => {
+  if (Platform.OS === 'android') {
+    return 0;
+  }
+
+  // Apple identifier
+  const deviceId = DeviceInfo.getDeviceId();
+
+  // Extract the numbers from the deviceId string using a regular expression
+  const versions = deviceId.match(/(\d+),(\d+)/);
+
+  if (!versions && versions.length < 3) {
+    return 0;
+  }
+
+  // Extracted numbers as strings
+  const majorVersion = versions[1];
+  const minorVersion = versions[2];
+
+  // Convert the extracted numbers to numeric values
+  const numericMajorVersion = parseInt(majorVersion, 10);
+  const numericMinorVersion = parseInt(minorVersion, 10);
+
+  const isNewerGenIphoneSE =
+    (numericMajorVersion === 12 && numericMinorVersion === 8) ||
+    (numericMajorVersion === 14 && numericMinorVersion === 6);
+
+  const isIphoneX =
+    (numericMajorVersion === 10 && numericMinorVersion === 3) ||
+    (numericMajorVersion === 10 && numericMinorVersion === 6);
+
+  // Home indicator is present since iPhone X series.
+  // Separate iphoneX check is here because older iPhone X is the only series that has ID version lower than 10,6.
+  // iPhone SE 2nd and 3rd gen also have higher ID version than 10,6.
+  if (
+    (isIphoneX || (numericMajorVersion >= 10 && numericMinorVersion >= 6)) &&
+    !isNewerGenIphoneSE
+  ) {
+    // Devices with home indicator
+    return 34;
+  }
+
+  // Devices without home indicator
+  return 0;
+};
 
 export const Device = {
   isIphoneX,

--- a/helpers/device-selector.js
+++ b/helpers/device-selector.js
@@ -17,10 +17,6 @@ export const IPHONE_12_MAX_LONG_SIDE = 926;
 
 export const NAVIGATION_HEADER_HEIGHT = 64;
 
-// Identifiers
-// iPhone10,3, iPhone10,6 - X.... Ne može veće od ovoga jer iPhone 8+ ima 10,5
-// 11+
-
 const xDimensionsMatch =
   height === IPHONE_X_LONG_SIDE || width === IPHONE_X_LONG_SIDE;
 
@@ -86,6 +82,8 @@ export const getHomeIndicatorPadding = () => {
   // Extract the numbers from the deviceId string using a regular expression
   const versions = deviceId.match(/(\d+),(\d+)/);
 
+  // Only checks if regex found X,Y, it does not resolve any of device ID-padding logic.
+  // If version is present, e.g. in iPhone 9,1, it'll always return array of length 3.
   if (!versions && versions.length < 3) {
     return 0;
   }
@@ -94,22 +92,22 @@ export const getHomeIndicatorPadding = () => {
   const majorVersion = versions[1];
   const minorVersion = versions[2];
 
-  // Convert the extracted numbers to numeric values
-  const numericMajorVersion = parseInt(majorVersion, 10);
-  const numericMinorVersion = parseInt(minorVersion, 10);
+  const decimalNumber = parseFloat(`${majorVersion}.${minorVersion}`);
 
-  const isNewerGenIphoneSE =
-    (numericMajorVersion === 12 && numericMinorVersion === 8) ||
-    (numericMajorVersion === 14 && numericMinorVersion === 6);
+  const excludedIphones = {
+    iPhone8: 10.4,
+    iPhone8plus: 10.5,
+    iPhoneSeGen2: 12.8,
+    iPhoneSeGen3: 14.6,
+  };
 
-  const isIphoneX =
-    (numericMajorVersion === 10 && numericMinorVersion === 3) ||
-    (numericMajorVersion === 10 && numericMinorVersion === 6);
-
-  // Home indicator is present since iPhone X series.
-  // Separate iphoneX check is here because older iPhone X is the only series that has ID version lower than 10,6.
-  // iPhone SE 2nd and 3rd gen also have higher ID version than 10,6.
-  if ((numericMajorVersion >= 11 || isIphoneX) && !isNewerGenIphoneSE) {
+  // Home indicator is present since iPhone X series with id of iPhone10,3.
+  // There are few newer models that do not have home indicator.
+  // They're included in excludedIphones object above.
+  if (
+    decimalNumber >= 10.3 &&
+    !Object.values(excludedIphones).includes(decimalNumber)
+  ) {
     // Devices with home indicator
     return 34;
   }

--- a/helpers/device-selector.js
+++ b/helpers/device-selector.js
@@ -92,7 +92,7 @@ export const getHomeIndicatorPadding = () => {
   const majorVersion = versions[1];
   const minorVersion = versions[2];
 
-  const decimalNumber = parseFloat(`${majorVersion}.${minorVersion}`);
+  const numericVersion = parseFloat(`${majorVersion}.${minorVersion}`);
 
   const excludedIphones = {
     iPhone8: 10.4,
@@ -105,8 +105,8 @@ export const getHomeIndicatorPadding = () => {
   // There are few newer models that do not have home indicator.
   // They're included in excludedIphones object above.
   if (
-    decimalNumber >= 10.3 &&
-    !Object.values(excludedIphones).includes(decimalNumber)
+    numericVersion >= 10.3 &&
+    !Object.values(excludedIphones).includes(numericVersion)
   ) {
     // Devices with home indicator
     return 34;

--- a/helpers/device-selector.js
+++ b/helpers/device-selector.js
@@ -109,10 +109,7 @@ export const getHomeIndicatorPadding = () => {
   // Home indicator is present since iPhone X series.
   // Separate iphoneX check is here because older iPhone X is the only series that has ID version lower than 10,6.
   // iPhone SE 2nd and 3rd gen also have higher ID version than 10,6.
-  if (
-    (isIphoneX || (numericMajorVersion >= 10 && numericMinorVersion >= 6)) &&
-    !isNewerGenIphoneSE
-  ) {
+  if ((numericMajorVersion >= 11 || isIphoneX) && !isNewerGenIphoneSE) {
     // Devices with home indicator
     return 34;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.3.0",
+  "version": "6.4.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.3.0",
+  "version": "6.4.0-rc.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -7,8 +7,8 @@ import {
   INCLUDE,
   inverseColorBrightnessForAmount,
 } from '@shoutem/theme';
+import { getHomeIndicatorPadding } from './helpers/device-selector';
 import {
-  IPHONE_X_HOME_INDICATOR_PADDING,
   IPHONE_X_NOTCH_PADDING,
   IPHONE_XR_NOTCH_PADDING,
   NAVIGATION_BAR_HEIGHT,
@@ -956,20 +956,12 @@ export default () => {
       },
 
       '.with-notch-padding': {
-        paddingBottom: Device.select({
-          iPhoneX: IPHONE_X_HOME_INDICATOR_PADDING,
-          iPhoneXR: IPHONE_X_HOME_INDICATOR_PADDING,
-          default: 0,
-        }),
+        paddingBottom: getHomeIndicatorPadding(),
       },
 
       'shoutem.ui.ListView': {
         listContent: {
-          paddingBottom: Device.select({
-            iPhoneX: IPHONE_X_HOME_INDICATOR_PADDING,
-            iPhoneXR: IPHONE_X_HOME_INDICATOR_PADDING,
-            default: 0,
-          }),
+          paddingBottom: getHomeIndicatorPadding(),
         },
       },
 

--- a/theme.js
+++ b/theme.js
@@ -856,6 +856,10 @@ export default () => {
     'shoutem.ui.View': {
       [INCLUDE]: ['commonVariants', 'guttersPadding'],
 
+      '.with-home-indicator-padding': {
+        paddingBottom: getHomeIndicatorPadding(),
+      },
+
       '.horizontal': {
         [INCLUDE]: ['horizontalFlexAlignment'],
         flexDirection: 'row',

--- a/theme.js
+++ b/theme.js
@@ -955,7 +955,13 @@ export default () => {
         backgroundColor: resolveVariable('paperColor'),
       },
 
+      // This was created with home indicator padding in mind. Use with-home-indicator-padding
+      // if you need bottom padding. For actual notch - top of the screen padding, use SafeAreaView component instead.
       '.with-notch-padding': {
+        paddingBottom: getHomeIndicatorPadding(),
+      },
+
+      '.with-home-indicator-padding': {
         paddingBottom: getHomeIndicatorPadding(),
       },
 


### PR DESCRIPTION
## Summary
Our `with-notch-padding` styleName was calculating padding for home indicator (not notch), and it was working only for selected iPhone models - iPhone X and XR. If user had newer devices, bottom padding wouldn't apply.

iPhone identifiers can be found here:
https://www.theiphonewiki.com/wiki/Models#iPhone

- Add new calculation for bottom padding, based on iPhone devices with home indicator. Devices with home indicator calculation is based on iPhone ID, a string containing Apple's internal version for each model, e.g. `iPhone16,2`
  - Home indicator is present on all iPhone devices with ID 10,3 or greater, except:
    - iPhone 8 and iPhone 8 plus newer generations
    - 2nd and 3rd gen iPhoneSE
- Created new styleName for `View`, `Screen` and `ListView`, with more appropriate name - `with-home-indicator-padding`, which should be used in place of `with-notch-padding`
- Adjusted `with-notch-padding` to use new calculation, while keeping backwards compatibility


### Screenshots


<table>
<tr>
<td>with-home-indicator-padding</td>
<td>NEW with-notch-padding</td>
</tr>
<tr>
<td><img src="https://github.com/shoutem/ui/assets/57353746/2ce7a6a4-d92a-47ac-8197-5c1e20501a99" /></td>
<td><img src="https://github.com/shoutem/ui/assets/57353746/6e719bb0-c9ee-4a25-9b24-6d1f3b26e522" /></td>
</tr>
</table>
