### PR TITLE
Feature/fix simplehtml video embeds

### DIFF
--- a/html/components/IframeRenderer.js
+++ b/html/components/IframeRenderer.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import YoutubePlayer from 'react-native-youtube-iframe';
 import { Vimeo } from 'react-native-vimeo-iframe';
+import YoutubePlayer from 'react-native-youtube-iframe';
 import iframe from '@native-html/iframe-plugin';
 import PropTypes from 'prop-types';
 import { Text } from '../../components/Text';
@@ -47,7 +47,12 @@ const IframeRenderer = props => {
     const regExMatches = url.match(vimeoIdRegEx);
     const vimeoId = regExMatches[1];
 
-    return <Vimeo videoId={vimeoId} />;
+    return (
+      <Vimeo
+        videoId={vimeoId}
+        style={{ height: shoutemStyle.vimeoVideo.height }}
+      />
+    );
   }
 
   return iframe(props);

--- a/html/components/IframeRenderer.js
+++ b/html/components/IframeRenderer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import YoutubePlayer from 'react-native-youtube-iframe';
+import { Vimeo } from 'react-native-vimeo-iframe';
 import iframe from '@native-html/iframe-plugin';
 import PropTypes from 'prop-types';
 import { Text } from '../../components/Text';
@@ -44,9 +45,9 @@ const IframeRenderer = props => {
   if (url && url.includes('vimeo')) {
     const vimeoIdRegEx = /(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^\/]*)\/videos\/|album\/(?:\d+)\/video\/|video\/|)(\d+)(?:[a-zA-Z0-9_\-]+)?/i;
     const regExMatches = url.match(vimeoIdRegEx);
-    const videoId = regExMatches[1];
+    const vimeoId = regExMatches[1];
 
-    <Vimeo videoId={videoId} />;
+    return <Vimeo videoId={vimeoId} />;
   }
 
   return iframe(props);

--- a/html/components/IframeRenderer.js
+++ b/html/components/IframeRenderer.js
@@ -41,6 +41,14 @@ const IframeRenderer = props => {
     );
   }
 
+  if (url && url.includes('vimeo')) {
+    const vimeoIdRegEx = /(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^\/]*)\/videos\/|album\/(?:\d+)\/video\/|video\/|)(\d+)(?:[a-zA-Z0-9_\-]+)?/i;
+    const regExMatches = url.match(vimeoIdRegEx);
+    const videoId = regExMatches[1];
+
+    <Vimeo videoId={videoId} />;
+  }
+
   return iframe(props);
 };
 

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { connectStyle } from '@shoutem/theme';
 import { View } from '../../components/View';
 import { resolveMaxWidth } from '../services/Dimensions';
+import { onElement } from '../services/DomVisitors';
 import AttachmentRenderer from './AttachmentRenderer';
 import IframeRenderer from './IframeRenderer';
 
@@ -33,6 +34,12 @@ class SimpleHtml extends PureComponent {
       : Linking.openURL(href);
   }
 
+  /**
+   * Our Rich Text Editor wraps <iframe> elements with <figure> element when video is added.
+   * Figure element is causing enormous white space below the video, so we need to remove
+   * the style causing it.
+   */
+
   render() {
     const {
       style,
@@ -40,6 +47,7 @@ class SimpleHtml extends PureComponent {
       customTagStyles,
       unsupportedVideoFormatMessage,
       attachments,
+      domVisitors,
       ...otherProps
     } = this.props;
 
@@ -102,6 +110,7 @@ class SimpleHtml extends PureComponent {
       },
       WebView,
       ignoredTags: IGNORED_TAGS,
+      domVisitors,
     };
 
     return (
@@ -119,6 +128,7 @@ SimpleHtml.propTypes = {
   customAlterNode: PropTypes.func,
   customHandleLinkPress: PropTypes.func,
   customTagStyles: PropTypes.object,
+  domVisitors: PropTypes.object,
   unsupportedVideoFormatMessage: PropTypes.string,
 };
 
@@ -129,6 +139,7 @@ SimpleHtml.defaultProps = {
   customHandleLinkPress: undefined,
   customTagStyles: undefined,
   unsupportedVideoFormatMessage: undefined,
+  domVisitors: { onElement },
 };
 
 export default connectStyle('shoutem.ui.SimpleHtml')(SimpleHtml);

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -34,12 +34,6 @@ class SimpleHtml extends PureComponent {
       : Linking.openURL(href);
   }
 
-  /**
-   * Our Rich Text Editor wraps <iframe> elements with <figure> element when video is added.
-   * Figure element is causing enormous white space below the video, so we need to remove
-   * the style causing it.
-   */
-
   render() {
     const {
       style,

--- a/html/services/DomVisitors.js
+++ b/html/services/DomVisitors.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 // Shoutem RTE component wraps any video attachment (hosted inside iframe) with <figure>
 // element. That element contains style that breaks the SimpleHtml UI - enormous blank
 // space below attachment.
@@ -6,7 +8,9 @@ export const removeShoutemRteVideoAttachmentWrapper = element => {
   if (
     element.name === 'figure' &&
     element.children.length > 0 &&
-    element.children[0].name === 'iframe'
+    // <figure> can have multiple generated children too - type:text. Probably caused by empty space between
+    // figure and iframe elements in generated HTML.
+    _.some(element.children, ({ name }) => name === 'iframe')
   ) {
     // Remove height and padding-bottom styles because they break the UI
     element.attribs.style = element.attribs.style

--- a/html/services/DomVisitors.js
+++ b/html/services/DomVisitors.js
@@ -1,0 +1,30 @@
+// Shoutem RTE component wraps any video attachment (hosted inside iframe) with <figure>
+// element. That element contains style that breaks the SimpleHtml UI - enormous blank
+// space below attachment.
+// This function removes height and padding-bottom styles from figure to fix this UI issue.
+export const removeShoutemRteVideoAttachmentWrapper = element => {
+  if (
+    element.name === 'figure' &&
+    element.children.length > 0 &&
+    element.children[0].name === 'iframe'
+  ) {
+    // Remove height and padding-bottom styles because they break the UI
+    element.attribs.style = element.attribs.style
+      ? element.attribs.style
+          .replace(/height:[^;]+;?/, '')
+          .replace(/padding-bottom:[^;]+;?/, '')
+      : '';
+  }
+
+  return element;
+};
+
+/**
+ * Collection of node (HTML element) alteration callbacks. Define any html element
+ * manipulations inside.
+ * @param {*} element - HTML element to check against and manipulate if necessary
+ * @returns Manipulated HTML element
+ */
+export const onElement = element => {
+  return removeShoutemRteVideoAttachmentWrapper(element);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.4.0-rc.0",
+  "version": "6.4.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "6.3.0",
+      "version": "6.4.0-rc.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -38,6 +38,7 @@
         "react-native-svg": "12.3.0",
         "react-native-svg-transformer": "1.0.0",
         "react-native-toast-message": "2.1.5",
+        "react-native-vimeo-iframe": "1.2.1",
         "react-native-webview": "11.23.0",
         "react-native-youtube-iframe": "2.2.2",
         "stream": "0.0.2",
@@ -16979,6 +16980,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-vimeo-iframe": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-vimeo-iframe/-/react-native-vimeo-iframe-1.2.1.tgz",
+      "integrity": "sha512-+LBbjSpzn5z6Olx41pOk3n2bq1t8KWJKjHwdVIxUUGdijr+cOvDhS3IKErtwmPdnzLTpB2YdRmMFoUwV2X17Vw==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-webview": "*"
+      }
+    },
     "node_modules/react-native-webview": {
       "version": "11.23.0",
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.23.0.tgz",
@@ -32584,6 +32595,12 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.1.5.tgz",
       "integrity": "sha512-mk3rELtBEhrhWBCN6CTaw0gypgL9ZNauX3xx1LUs4uee9vc0pVsghrKxO57vroUCcNL2hDeZSLJWdQNMCkGeaQ==",
+      "requires": {}
+    },
+    "react-native-vimeo-iframe": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-vimeo-iframe/-/react-native-vimeo-iframe-1.2.1.tgz",
+      "integrity": "sha512-+LBbjSpzn5z6Olx41pOk3n2bq1t8KWJKjHwdVIxUUGdijr+cOvDhS3IKErtwmPdnzLTpB2YdRmMFoUwV2X17Vw==",
       "requires": {}
     },
     "react-native-webview": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-native-toast-message": "2.1.5",
     "react-native-webview": "11.23.0",
     "react-native-youtube-iframe": "2.2.2",
+    "react-native-vimeo-iframe": "1.2.1",
     "stream": "0.0.2",
     "tinycolor2": "1.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.4.0-rc.0",
+  "version": "6.4.1-rc.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -2284,6 +2284,10 @@ export default () => {
         height: responsiveWidth(194),
         paddingBottom: resolveVariable('smallGutter'),
       },
+      // Just enough to display portrait mode Vimeo videos and all Vimeo player controls
+      vimeoVideo: {
+        height: responsiveWidth(220),
+      },
       fallback: {
         width: window.width,
         height: 40,


### PR DESCRIPTION
## Summary
Shoutem's RTE component is wrapping any video attachment's `iframe` element inside `figure` element.
That `figure` element holds the style that breaks the UI - adds lots of blank space under video attachment.
`figure` element can't be "turned off" by RTE component AND it also doesn't work if that element is removed with regex, so that's not an option.
We have to remove it on client side, prior to rendering, by manipulating the source html.

- Add `domVisitors` to `SimpleHtml` component
  - Define default, Shoutem specific `onElement` domVisitor, while still allowing component users to override `domVisitors`
  - `onElement` and `removeShoutemRteVideoAttachmentWrapper` are exported to give component users more control over defining `domVisitors`

## Side changes
- Fix Vimeo video attachments breaking UI - these video embeds wouldn't respect `SimpleHtml` right padding
  - Use `react-native-vimeo-iframe` to render Vimeo embeds as a part of iframes inside our `SimpleHtml`
  - Set the height for Vimeo embeds just enough to support vertical videos & render all Vimeo player controls.

### Screenshots
**P.S.**
Ignore last Android image, Vimeo video is stretched to right edge. This was fixed when new Vimeo embedded video component was added. It renders the same as on iOS - check first image.
I have hard time running and using Android simulator, takes waaaaay to long to run it again just to get this screenshot.

<table>
<tr>
<td colSpan="3">iOS</td>
</tr>
<tr>
<td><img src="https://github.com/shoutem/mobile/assets/57353746/e46028af-9f4e-40b7-a555-3ffc0f789922" /></td>
<td><img src="https://github.com/shoutem/mobile/assets/57353746/bf8fe8a4-ff0e-4e92-b2d7-85868ad4061d" /></td>
</tr>

<tr>
<td colSpan="3">Android</td>
</tr>
<tr>
<td><img src="https://github.com/shoutem/mobile/assets/57353746/15352578-fb28-4481-acf7-c9e4ca16c6d6" /></td>
<td></td>
</tr>
</table>