### PR TITLE
Feature/seext 12720 wall of blank space after video attachments from rte

### DIFF
--- a/html/components/IframeRenderer.js
+++ b/html/components/IframeRenderer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Vimeo } from 'react-native-vimeo-iframe';
 import YoutubePlayer from 'react-native-youtube-iframe';
 import iframe from '@native-html/iframe-plugin';
 import PropTypes from 'prop-types';
@@ -37,6 +38,19 @@ const IframeRenderer = props => {
         }}
         height={shoutemStyle.video.height}
         videoId={youtubeId}
+      />
+    );
+  }
+
+  if (url && url.includes('vimeo')) {
+    const vimeoIdRegEx = /(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^\/]*)\/videos\/|album\/(?:\d+)\/video\/|video\/|)(\d+)(?:[a-zA-Z0-9_\-]+)?/i;
+    const regExMatches = url.match(vimeoIdRegEx);
+    const vimeoId = regExMatches[1];
+
+    return (
+      <Vimeo
+        videoId={vimeoId}
+        style={{ height: shoutemStyle.vimeoVideo.height }}
       />
     );
   }

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import { connectStyle } from '@shoutem/theme';
 import { View } from '../../components/View';
 import { resolveMaxWidth } from '../services/Dimensions';
+import { onElement } from '../services/DomVisitors';
 import AttachmentRenderer from './AttachmentRenderer';
 import IframeRenderer from './IframeRenderer';
 
@@ -40,6 +41,7 @@ class SimpleHtml extends PureComponent {
       customTagStyles,
       unsupportedVideoFormatMessage,
       attachments,
+      domVisitors,
       ...otherProps
     } = this.props;
 
@@ -102,6 +104,7 @@ class SimpleHtml extends PureComponent {
       },
       WebView,
       ignoredTags: IGNORED_TAGS,
+      domVisitors,
     };
 
     return (
@@ -119,6 +122,7 @@ SimpleHtml.propTypes = {
   customAlterNode: PropTypes.func,
   customHandleLinkPress: PropTypes.func,
   customTagStyles: PropTypes.object,
+  domVisitors: PropTypes.object,
   unsupportedVideoFormatMessage: PropTypes.string,
 };
 
@@ -129,6 +133,7 @@ SimpleHtml.defaultProps = {
   customHandleLinkPress: undefined,
   customTagStyles: undefined,
   unsupportedVideoFormatMessage: undefined,
+  domVisitors: { onElement },
 };
 
 export default connectStyle('shoutem.ui.SimpleHtml')(SimpleHtml);

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -104,7 +104,7 @@ class SimpleHtml extends PureComponent {
       },
       WebView,
       ignoredTags: IGNORED_TAGS,
-      domVisitors,
+      domVisitors: { onElement },
     };
 
     return (

--- a/html/services/DomVisitors.js
+++ b/html/services/DomVisitors.js
@@ -1,0 +1,34 @@
+import _ from 'lodash';
+
+// Shoutem RTE component wraps any video attachment (hosted inside iframe) with <figure>
+// element. That element contains style that breaks the SimpleHtml UI - enormous blank
+// space below attachment.
+// This function removes height and padding-bottom styles from figure to fix this UI issue.
+export const removeShoutemRteVideoAttachmentWrapper = element => {
+  if (
+    element.name === 'figure' &&
+    element.children.length > 0 &&
+    // <figure> can have multiple generated children too - type:text. Probably caused by empty space between
+    // figure and iframe elements in generated HTML.
+    _.some(element.children, ({ name }) => name === 'iframe')
+  ) {
+    // Remove height and padding-bottom styles because they break the UI
+    element.attribs.style = element.attribs.style
+      ? element.attribs.style
+          .replace(/height:[^;]+;?/, '')
+          .replace(/padding-bottom:[^;]+;?/, '')
+      : '';
+  }
+
+  return element;
+};
+
+/**
+ * Collection of node (HTML element) alteration callbacks. Define any html element
+ * manipulations inside.
+ * @param {*} element - HTML element to check against and manipulate if necessary
+ * @returns Manipulated HTML element
+ */
+export const onElement = element => {
+  return removeShoutemRteVideoAttachmentWrapper(element);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.3.0",
+  "version": "6.3.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.3.0",
+  "version": "6.3.1-rc.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -2327,6 +2327,10 @@ export default () => {
         height: responsiveWidth(194),
         paddingBottom: resolveVariable('smallGutter'),
       },
+      // Just enough to display portrait mode Vimeo videos and all Vimeo player controls
+      vimeoVideo: {
+        height: responsiveWidth(220),
+      },
       fallback: {
         width: window.width,
         height: 40,

--- a/theme.js
+++ b/theme.js
@@ -2329,7 +2329,7 @@ export default () => {
       },
       // Just enough to display portrait mode Vimeo videos and all Vimeo player controls
       vimeoVideo: {
-        height: responsiveWidth(220),
+        height: responsiveHeight(220),
       },
       fallback: {
         width: window.width,


### PR DESCRIPTION
## Summary
Shoutem's RTE component is wrapping video attachment's `iframe` element inside `figure` element.
That `figure` element holds the style that breaks the UI - adds lots of blank space under video attachment.

<table>
<tr>
<td><img width="250" src="https://github.com/shoutem/ui/assets/57353746/03761a98-bcff-47d3-b80e-00f6eca77730" /></td>
<td><img width="250" src="https://github.com/shoutem/ui/assets/57353746/41ecbf0b-0181-4da8-80e1-72afbc9b6200" /></td>
</tr>
</table>

`figure` element can't be "turned off" by RTE component AND it also doesn't work if that element is removed with regex, so that's not an option.
We have to remove it on client side, prior to rendering, by manipulating the source html.

- Add `domVisitors` to `SimpleHtml` component
  - Define default, Shoutem specific `onElement` domVisitor, while still allowing component users to override `domVisitors`
  - `onElement` and `removeShoutemRteVideoAttachmentWrapper` are exported to give component users more control over defining `domVisitors`

## Side changes
- Fix Vimeo video attachments breaking UI - these video embeds wouldn't respect `SimpleHtml` right padding
  - Use `react-native-vimeo-iframe` to render Vimeo embeds as a part of iframes inside our `SimpleHtml`
  - Set the height for Vimeo embeds just enough to support vertical videos & render all Vimeo player controls.

### Screenshots
<table>
<tr>
<td colSpan="3">iOS</td>
</tr>
<tr>
<td><img src="https://github.com/shoutem/ui/assets/57353746/04be7877-72f8-4b3b-851e-d7b7898b35ad" /></td>
<td><img src="https://github.com/shoutem/ui/assets/57353746/4a22727f-959b-486e-84fc-bcb7eedc82cc" /></td>
<td><img src="https://github.com/shoutem/ui/assets/57353746/53ace439-0174-456a-bdd0-3da8510524da" /></td>
</tr>

<tr>
<td colSpan="3">Android</td>
</tr>
<tr>
<td><img src="https://github.com/shoutem/ui/assets/57353746/04e93843-81d7-41d4-805a-c2b3eaee7b6e" /></td>
<td><img src="https://github.com/shoutem/ui/assets/57353746/4815ea50-3417-4f87-8950-47df13fbcc8f" /></td>
<td><img src="https://github.com/shoutem/ui/assets/57353746/e576c112-fa2f-4def-8825-737b892e4cff" /></td>
</tr>
</table>