### PR TITLE
Hc/seext 12726 video from cms content not displaying video

### DIFF
--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -40,10 +40,14 @@ class SimpleHtml extends PureComponent {
     const {
       style,
       body,
-      customTagStyles,
       unsupportedVideoFormatMessage,
       attachments,
-      domVisitors,
+      customDomVisitors,
+      customCustomRenderers,
+      customTagStyles,
+      customHtmlElementModels,
+      customIgnoredStyles,
+      customRendererProps,
       ...otherProps
     } = this.props;
 
@@ -79,6 +83,7 @@ class SimpleHtml extends PureComponent {
         />
       ),
       video: VideoRenderer,
+      ...customCustomRenderers,
     };
 
     const htmlProps = {
@@ -88,7 +93,12 @@ class SimpleHtml extends PureComponent {
       tagsStyles: _.omitBy(tagStyles, tagStyle => !tagStyle),
       systemFonts: [...defaultSystemFonts, style.baseFont.fontFamily],
       baseStyle: style.baseFont,
-      ignoredStyles: ['fontFamily', 'letterSpacing', 'transform'],
+      ignoredStyles: [
+        'fontFamily',
+        'letterSpacing',
+        'transform',
+        ...customIgnoredStyles,
+      ],
       renderers: customRenderers,
       renderersProps: {
         table: {
@@ -100,15 +110,17 @@ class SimpleHtml extends PureComponent {
             renderToHardwareTextureAndroid: true,
           },
         },
+        ...customRendererProps,
       },
       customHTMLElementModels: {
         table: tableModel,
         iframe: iframeModel,
         video: videoModel,
+        ...customHtmlElementModels,
       },
       WebView,
       ignoredTags: IGNORED_TAGS,
-      domVisitors,
+      domVisitors: { onElement, ...customDomVisitors },
     };
 
     return (
@@ -123,8 +135,12 @@ SimpleHtml.propTypes = {
   style: PropTypes.object.isRequired,
   attachments: PropTypes.array,
   body: PropTypes.string,
-  customAlterNode: PropTypes.func,
+  customCustomRenderers: PropTypes.object,
+  customDomVisitors: PropTypes.object,
   customHandleLinkPress: PropTypes.func,
+  customHtmlElementModels: PropTypes.object,
+  customIgnoredStyles: PropTypes.arrayOf(PropTypes.string),
+  customRendererProps: PropTypes.object,
   customTagStyles: PropTypes.object,
   domVisitors: PropTypes.object,
   unsupportedVideoFormatMessage: PropTypes.string,
@@ -133,11 +149,15 @@ SimpleHtml.propTypes = {
 SimpleHtml.defaultProps = {
   attachments: undefined,
   body: undefined,
-  customAlterNode: undefined,
   customHandleLinkPress: undefined,
-  customTagStyles: undefined,
+  customTagStyles: {},
   unsupportedVideoFormatMessage: undefined,
   domVisitors: { onElement },
+  customDomVisitors: {},
+  customCustomRenderers: {},
+  customHtmlElementModels: {},
+  customIgnoredStyles: [],
+  customRendererProps: {},
 };
 
 export default connectStyle('shoutem.ui.SimpleHtml')(SimpleHtml);

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -1,6 +1,10 @@
 import React, { PureComponent } from 'react';
 import { Linking } from 'react-native';
-import Html, { defaultSystemFonts } from 'react-native-render-html';
+import Html, {
+  defaultSystemFonts,
+  HTMLContentModel,
+  HTMLElementModel,
+} from 'react-native-render-html';
 import WebView from 'react-native-webview';
 import { iframeModel } from '@native-html/iframe-plugin';
 import table, {
@@ -13,6 +17,7 @@ import autoBindReact from 'auto-bind/react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { connectStyle } from '@shoutem/theme';
+import VideoRenderer from '@shoutem/ui/html/components/VideoRenderer';
 import { View } from '../../components/View';
 import { resolveMaxWidth } from '../services/Dimensions';
 import { onElement } from '../services/DomVisitors';
@@ -76,6 +81,7 @@ class SimpleHtml extends PureComponent {
           style={style}
         />
       ),
+      video: VideoRenderer,
     };
 
     const htmlProps = {
@@ -97,10 +103,34 @@ class SimpleHtml extends PureComponent {
             renderToHardwareTextureAndroid: true,
           },
         },
+        video: (htmlAttribs, _children, _convertedCSSStyles, passProps) => {
+          return (
+            <View
+              key={passProps.key}
+              style={{
+                width: '100%',
+                aspectRatio: 16.0 / 9.0,
+                marginTop: 16,
+                marginBottom: 16,
+              }}
+            >
+              <WebView
+                scrollEnabled={false}
+                source={{ uri: htmlAttribs.src }}
+                style={{ flex: 1, width: '100%', aspectRatio: 16.0 / 9.0 }}
+              />
+            </View>
+          );
+        },
       },
       customHTMLElementModels: {
         table: tableModel,
         iframe: iframeModel,
+        video: HTMLElementModel.fromCustomModel({
+          contentModel: HTMLContentModel.block,
+          tagName: 'video',
+          isOpaque: true,
+        }),
       },
       WebView,
       ignoredTags: IGNORED_TAGS,

--- a/html/components/SimpleHtml.js
+++ b/html/components/SimpleHtml.js
@@ -1,10 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Linking } from 'react-native';
-import Html, {
-  defaultSystemFonts,
-  HTMLContentModel,
-  HTMLElementModel,
-} from 'react-native-render-html';
+import Html, { defaultSystemFonts } from 'react-native-render-html';
 import WebView from 'react-native-webview';
 import { iframeModel } from '@native-html/iframe-plugin';
 import table, {
@@ -18,6 +14,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { connectStyle } from '@shoutem/theme';
 import VideoRenderer from '@shoutem/ui/html/components/VideoRenderer';
+import { videoModel } from '@shoutem/ui/html/services/HTMLElementModels';
 import { View } from '../../components/View';
 import { resolveMaxWidth } from '../services/Dimensions';
 import { onElement } from '../services/DomVisitors';
@@ -103,38 +100,15 @@ class SimpleHtml extends PureComponent {
             renderToHardwareTextureAndroid: true,
           },
         },
-        video: (htmlAttribs, _children, _convertedCSSStyles, passProps) => {
-          return (
-            <View
-              key={passProps.key}
-              style={{
-                width: '100%',
-                aspectRatio: 16.0 / 9.0,
-                marginTop: 16,
-                marginBottom: 16,
-              }}
-            >
-              <WebView
-                scrollEnabled={false}
-                source={{ uri: htmlAttribs.src }}
-                style={{ flex: 1, width: '100%', aspectRatio: 16.0 / 9.0 }}
-              />
-            </View>
-          );
-        },
       },
       customHTMLElementModels: {
         table: tableModel,
         iframe: iframeModel,
-        video: HTMLElementModel.fromCustomModel({
-          contentModel: HTMLContentModel.block,
-          tagName: 'video',
-          isOpaque: true,
-        }),
+        video: videoModel,
       },
       WebView,
       ignoredTags: IGNORED_TAGS,
-      domVisitors: { onElement },
+      domVisitors,
     };
 
     return (

--- a/html/components/VideoRenderer.js
+++ b/html/components/VideoRenderer.js
@@ -5,31 +5,66 @@ import {
 } from 'react-native-render-html';
 import WebView from 'react-native-webview';
 import { findOne } from 'domutils';
+import PropTypes from 'prop-types';
 
 function findSource(tnode) {
   if (tnode.attributes.src) {
     return tnode.attributes.src;
   }
+
   const sourceElms = findOne(
     elm => elm.tagName === 'source',
     tnode.domNode.children,
   );
+
   return sourceElms ? sourceElms.attribs.src : '';
 }
 
-const VideoRenderer = props => {
-  const { tnode, style } = props;
+/**
+ *
+ * Generate video html with only selected attributes and parameters.
+ * @returns HTML video element
+ */
+function generateVideoHtml(tnode) {
+  const url = findSource(tnode);
 
+  const containsTimeParameter = url.match(/(#|\?)t=[^&$]*/g, '');
+  // If video has no time parameter, we want to add time parameter at 0.1, just to be able to
+  // display the image, first frame of the video. Video tags that don't have autoplay attribute
+  // are not showing first frame without this solution.
+  // Otherwise, if user has defined time parameter, keep it as is.
+  const resolvedUrl = `${url}${containsTimeParameter ? '' : '#t=0.1'}`;
+
+  return `<video controls src="${resolvedUrl}" style="width: 100%; height: 100%;"/>`;
+}
+
+export const VideoRenderer = ({ tnode, style }) => {
   const computeMaxWidth = useComputeMaxWidthForTag('video');
   const width = computeMaxWidth(useContentWidth());
+
+  // Using uri as a Webview source is not an option, because we don't have as much control of video.
+  // E.g. if video from uri has autoplay=true, we can't prevent it from auto-playing when Webview renders.
+  // Instead, create video HTML element with only picked attributes and parameters.
+  const html = generateVideoHtml(tnode);
 
   return (
     <WebView
       scrollEnabled={false}
-      source={{ uri: findSource(tnode) }}
+      source={{
+        html,
+      }}
       style={[{ aspectRatio: 16 / 9 }, style, { width }]}
     />
   );
+};
+
+VideoRenderer.propTypes = {
+  tnode: PropTypes.object.isRequired,
+  style: PropTypes.object,
+};
+
+VideoRenderer.defaultProps = {
+  style: {},
 };
 
 export default VideoRenderer;

--- a/html/components/VideoRenderer.js
+++ b/html/components/VideoRenderer.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import {
+  useComputeMaxWidthForTag,
+  useContentWidth,
+} from 'react-native-render-html';
+import WebView from 'react-native-webview';
+import { findOne } from 'domutils';
+
+function findSource(tnode) {
+  if (tnode.attributes.src) {
+    return tnode.attributes.src;
+  }
+  const sourceElms = findOne(
+    elm => elm.tagName === 'source',
+    tnode.domNode.children,
+  );
+  return sourceElms ? sourceElms.attribs.src : '';
+}
+
+const VideoRenderer = props => {
+  const { tnode, style } = props;
+
+  const computeMaxWidth = useComputeMaxWidthForTag('video');
+  const width = computeMaxWidth(useContentWidth());
+
+  return (
+    <WebView
+      scrollEnabled={false}
+      source={{ uri: findSource(tnode) }}
+      style={[{ aspectRatio: 16 / 9 }, style, { width }]}
+    />
+  );
+};
+
+export default VideoRenderer;

--- a/html/services/DomVisitors.js
+++ b/html/services/DomVisitors.js
@@ -1,16 +1,19 @@
 import _ from 'lodash';
 
-// Shoutem RTE component wraps any video attachment (hosted inside iframe) with <figure>
+// Shoutem RTE component wraps any video attachment (hosted inside iframe or video) with <figure>
 // element. That element contains style that breaks the SimpleHtml UI - enormous blank
 // space below attachment.
 // This function removes height and padding-bottom styles from figure to fix this UI issue.
 export const removeShoutemRteVideoAttachmentWrapper = element => {
   if (
-    element.name === 'figure' &&
+    (element.name === 'figure' || element.name === 'video') &&
     element.children.length > 0 &&
     // <figure> can have multiple generated children too - type:text. Probably caused by empty space between
     // figure and iframe elements in generated HTML.
-    _.some(element.children, ({ name }) => name === 'iframe')
+    _.some(
+      element.children,
+      ({ name }) => name === 'iframe' || name === 'video',
+    )
   ) {
     // Remove height and padding-bottom styles because they break the UI
     element.attribs.style = element.attribs.style

--- a/html/services/HTMLElementModels.js
+++ b/html/services/HTMLElementModels.js
@@ -1,0 +1,7 @@
+import { HTMLContentModel, HTMLElementModel } from 'react-native-render-html';
+
+export const videoModel = HTMLElementModel.fromCustomModel({
+  contentModel: HTMLContentModel.block,
+  tagName: 'video',
+  isOpaque: true,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.3.2",
+  "version": "6.3.3-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "6.3.2",
+  "version": "6.3.3-rc.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
Shoutem RTE would use `iframe` tag for video attachments most of the time, but in rare cases it'd use `video` tag instead.
Our `SimpleHtml` component didn't have `video` tag renderer defined, thus video tags wouldn't render in app.

- Added `video` tag renderer
  - Using `WebView` to render videos
  - Using `html` as `WebView` source because it gives us more control over video when compared to `uri`. When using `uri` as source, video html is defined at host and we've got no control over it. This way, we pick attributes and values we want to attach to video, before rendering it with `WebView`
- `figure` is wrapping any video attachments coming from Shoutem RTE, the same goes for `video` tag. Included video tags into function that removes figure style breaking UI output - big blank space under video
- Added more props to `SimpleHtml`, so that it's implementations can have more control over it

<table>
<tr><td>iOS</td><td>Android</td></tr>
<tr><td>
<img width="379" alt="Screenshot 2023-12-22 at 13 24 41" src="https://github.com/shoutem/ui/assets/57353746/df4d466e-b264-4bc8-af2e-71c27444158a"></td>
<td><img width="380" alt="Screenshot 2023-12-22 at 13 20 55" src="https://github.com/shoutem/ui/assets/57353746/77731355-e65a-49d4-9d1c-f7ea5674e7ef"></td></tr>
</table>


