### PR TITLE
Fix/listview refresh control

### DIFF
--- a/components/ListView.js
+++ b/components/ListView.js
@@ -38,10 +38,17 @@ class ListView extends PureComponent {
   static getDerivedStateFromProps(props, state) {
     const isLoading = props.loading;
 
+    // If data is loading but no status updates were triggered, set status to loading.
     if (isLoading && state.status === Status.IDLE) {
       return { status: Status.LOADING };
     }
 
+    // If loading is done, set status back to idle.
+    if (!isLoading && state.status === Status.LOADING) {
+      return { status: Status.IDLE}
+    }
+
+    // Return all other statuses as they are.
     return { status: state.status ?? Status.IDLE };
   }
 

--- a/components/ListView.js
+++ b/components/ListView.js
@@ -7,6 +7,7 @@ import {
   StatusBar,
   View,
 } from 'react-native';
+import { RefreshControl as WebRefreshControl } from 'react-native-web-refresh-control';
 import autoBindReact from 'auto-bind/react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
@@ -37,15 +38,11 @@ class ListView extends PureComponent {
   static getDerivedStateFromProps(props, state) {
     const isLoading = props.loading;
 
-    if (isLoading) {
-      if (state.status !== Status.IDLE) {
-        // We are already in a loading status
-        return state;
-      }
-
+    if (isLoading && state.status === Status.IDLE) {
       return { status: Status.LOADING };
     }
-    return { status: Status.IDLE };
+
+    return { status: state.status ?? Status.IDLE };
   }
 
   constructor(props, context) {
@@ -78,6 +75,14 @@ class ListView extends PureComponent {
 
     if (onRefresh) {
       onRefresh();
+
+      // Adding timeout, until onRefresh becomes async function. Then, we'll be able to know when
+      // refresh is done and set status back to idle.
+      setTimeout(() => {
+        this.setState({
+          status: Status.IDLE,
+        });
+      }, 500);
     }
   }
 
@@ -301,6 +306,17 @@ class ListView extends PureComponent {
       ...style.refreshControl,
     };
     delete refreshControlStyle.tintColor;
+
+    if (Platform.OS === 'web') {
+      return (
+        <WebRefreshControl
+          onRefresh={this.onRefresh}
+          refreshing={status === Status.REFRESHING}
+          tintColor={style.refreshControl.tintColor}
+          style={refreshControlStyle}
+        />
+      );
+    }
 
     return (
       <RefreshControl

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-native-svg-transformer": "1.3.0",
     "react-native-toast-message": "2.1.5",
     "react-native-vimeo-iframe": "^1.2.1",
+    "react-native-web-refresh-control": "1.1.2",
     "react-native-webview": "11.23.0",
     "react-native-youtube-iframe": "2.2.2",
     "stream": "0.0.2",


### PR DESCRIPTION
Depeonds on https://github.com/shoutem/mobile/pull/2195

## Summary
- `ListView` doesn't support pull to refresh in web
  - Added `react-native-web-refresh-control` for pull to refresh support
- Our `ListView` doesn't resolve `REFRESHING` state properly. It is set to `REFRESHING`, but `getDerivedStateFromProps` was resetting it to idle/loading too fast, refresh control never managed to read updated state to be able to update `refreshing` prop
  - Web refresh depends on `refreshing` prop, React Native one doesn't. This is why we've never noticed this is not working as expected. RN refresh control will render itself, even if `refreshing` stays `false` all the time. But, in web, spinner will never render, unless `refreshing` is updated to true
    - Adjusted `getDerivedStateFromProps` to keep `REFRESHING` state when expected, instead of overriding it to idle/loading
  - `REFRESHING` was never dismissed either. This caused web refresh control to stay active after refreshing is done
    - We don't know when to dismiss `REFRESHING` state, because `onRefresh` callback is not async function. I've added small 500ms timeout to simulate processing, before setting state back to idle again
    

https://github.com/user-attachments/assets/fc8a0c94-fb16-4893-97db-490b9e908a18


    