### PR TITLE
block share in web

### DIFF
--- a/components/ShareButton.js
+++ b/components/ShareButton.js
@@ -3,6 +3,7 @@ import { Platform, Share } from 'react-native';
 import autoBindReact from 'auto-bind/react';
 import PropTypes from 'prop-types';
 import { connectStyle } from '@shoutem/theme';
+import { unavailableInWeb } from '../services';
 import { Button } from './Button';
 import { Icon } from './Icon';
 
@@ -41,7 +42,7 @@ class ShareButton extends PureComponent {
     }
 
     return (
-      <Button onPress={this.onShare} {...otherProps}>
+      <Button onPress={unavailableInWeb(this.onShare)} {...otherProps}>
         <Icon
           name={Platform.OS === 'ios' ? 'share' : 'share-android'}
           animationName={animationName}

--- a/services/index.js
+++ b/services/index.js
@@ -1,6 +1,7 @@
+export { unavailableInWeb } from './unavailableInWeb';
 export {
-  ThemeVariableResolver,
+  createScopedResolver,
   defaultResolver,
   resolveVariable,
-  createScopedResolver,
+  ThemeVariableResolver,
 } from './variableResolver';

--- a/services/unavailableInWeb.js
+++ b/services/unavailableInWeb.js
@@ -1,0 +1,17 @@
+import { Platform } from 'react-native';
+import { Toast } from '@shoutem/ui';
+
+const isWeb = Platform.OS === 'web';
+
+export const unavailableInWeb = callback => {
+  if (!isWeb) {
+    return callback;
+  }
+
+  return () =>
+    Toast.showInfo({
+      title: 'Feature currently unavailable',
+      message:
+        'This feature is currently unavailable in Web Preview. For better preview experience download Disclose app.',
+    });
+};

--- a/services/unavailableInWeb.js
+++ b/services/unavailableInWeb.js
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import { Toast } from '@shoutem/ui';
+import _ from 'lodash';
 
 const isWeb = Platform.OS === 'web';
 
@@ -7,6 +8,17 @@ export const unavailableInWeb = callback => {
   if (!isWeb) {
     return callback;
   }
+
+  // If callback is undefined, show toast immediatelly.
+  if (_.isUndefined(callback)) {
+    Toast.showInfo({
+      title: 'Feature currently unavailable',
+      message:
+        'This feature is currently unavailable in Web Preview. For better preview experience download Disclose app.',
+    });
+  }
+
+  // Otherwise, return callback to be executed on user action.
 
   return () =>
     Toast.showInfo({


### PR DESCRIPTION
Share is only supported for Safari. However, if you cancel share action, it shows uncaught error... 
I don't think it's worth enabling for Safari only, not for now.