### PR TITLE
Fix/icon-sizing

### DIFF
--- a/components/Icon/Icon.web.js
+++ b/components/Icon/Icon.web.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connectStyle } from '@shoutem/theme';
+import { View } from '../View';
+import { getIcon } from './services';
+
+function Icon({ name, style, ...otherProps }) {
+  const { color, width, height, ...otherStyle } = style;
+
+  const NamedIcon = getIcon(name);
+
+  if (!NamedIcon) {
+    // eslint-disable-next-line no-console
+    console.warn(`Icon with name '${name}' not found within the provided set`);
+
+    return null;
+  }
+
+  return (
+    // Sometimes, in web, svg icons are not resized as expected, unless svg is wrapped inside View.
+    <View>
+      <NamedIcon
+        fill={color}
+        width={width}
+        height={height}
+        style={{ ...otherStyle }}
+        {...otherProps}
+      />
+    </View>
+  );
+}
+
+Icon.propTypes = {
+  name: PropTypes.string.isRequired,
+  style: PropTypes.object.isRequired,
+};
+
+export default connectStyle('shoutem.ui.Icon')(Icon);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.11",
+  "version": "7.1.0-beta.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "7.1.0-beta.11",
+      "version": "7.1.0-beta.12",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.11",
+  "version": "7.1.0-beta.12",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Sometimes, in web, icons weren't having expected size.
It's probably because svg doesn't know how to flex inside some components (Button was the issue, parent component now).

Wrapping them inside View fixes the issue.