### PR TITLE
Feature/support action sheet styling

### DIFF
--- a/components/ActionSheet/ActionSheet.js
+++ b/components/ActionSheet/ActionSheet.js
@@ -43,7 +43,11 @@ const ActionSheet = ({
         {hasConfirmOptions && (
           <View style={style.segmentContainer}>
             {_.map(confirmOptions, option => (
-              <ActionSheetOption key={option.title} option={option} />
+              <ActionSheetOption
+                key={option.title}
+                option={option}
+                style={style.option}
+              />
             ))}
           </View>
         )}
@@ -55,6 +59,7 @@ const ActionSheet = ({
                   key={option.title}
                   cancelOption
                   option={option}
+                  style={style.option}
                 />
               ))}
             </View>

--- a/components/ActionSheet/ActionSheetOption.js
+++ b/components/ActionSheet/ActionSheetOption.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connectStyle } from '@shoutem/theme';
+import { isIos } from '../../services';
 import { Text } from '../Text';
 import { TouchableOpacity } from '../TouchableOpacity';
 
@@ -9,8 +10,10 @@ export const optionPropType = PropTypes.shape({
   onPress: PropTypes.func,
 });
 
-function ActionSheetOption({ style, option, cancelOption }) {
+function ActionSheetOption({ style, option, cancelOption, nativeStyle }) {
   const { title, onPress } = option;
+
+  const useIosTextColor = nativeStyle && isIos;
 
   return (
     <TouchableOpacity
@@ -18,7 +21,13 @@ function ActionSheetOption({ style, option, cancelOption }) {
       style={style.container}
       styleName="horizontal"
     >
-      <Text style={[style.text, cancelOption && style.cancelText]}>
+      <Text
+        style={[
+          style.text,
+          cancelOption && style.cancelText,
+          useIosTextColor && style.iosBlueTextColor,
+        ]}
+      >
         {title}
       </Text>
     </TouchableOpacity>
@@ -28,12 +37,14 @@ function ActionSheetOption({ style, option, cancelOption }) {
 ActionSheetOption.propTypes = {
   style: PropTypes.object.isRequired,
   cancelOption: PropTypes.bool,
+  nativeStyle: PropTypes.bool,
   option: optionPropType,
 };
 
 ActionSheetOption.defaultProps = {
   option: undefined,
   cancelOption: false,
+  nativeStyle: false,
 };
 
 export default connectStyle('shoutem.ui.ActionSheetOption')(ActionSheetOption);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.12",
+  "version": "7.1.0-beta.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "7.1.0-beta.12",
+      "version": "7.1.0-beta.13",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.12",
+  "version": "7.1.0-beta.13",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -2738,15 +2738,16 @@ export default () => {
       text: {
         fontSize: 15,
         letterSpacing: 0.38,
-        color: isAndroid
-          ? resolveVariable('primaryButtonText.color')
-          : '#007AFF', // iOS blue,
+        color: resolveVariable('primaryButtonText.color'),
         lineHeight: 24,
       },
       cancelText: {
-        color: isAndroid ? resolveVariable('errorText.color') : '#007AFF', // iOS blue,
+        color: resolveVariable('errorText.color'),
         textAlign: 'center',
         fontWeight: resolveFontWeight('700'),
+      },
+      iosBlueTextColor: {
+        color: '#007AFF',
       },
     },
 

--- a/theme.js
+++ b/theme.js
@@ -2733,17 +2733,18 @@ export default () => {
         paddingVertical: 16,
         borderBottomWidth: 1,
         borderColor: 'rgba(130, 130, 130, 0.1)',
+        alignItems: 'center',
       },
       text: {
         fontSize: 15,
         letterSpacing: 0.38,
-        color: resolveVariable('primaryButtonText.color'),
         lineHeight: 24,
+        color: '#007AFF', // iOS blue
       },
       cancelText: {
-        color: resolveVariable('errorText.color'),
         textAlign: 'center',
         fontWeight: resolveFontWeight('700'),
+        color: '#007AFF', // iOS blue
       },
     },
 

--- a/theme.js
+++ b/theme.js
@@ -2738,13 +2738,15 @@ export default () => {
       text: {
         fontSize: 15,
         letterSpacing: 0.38,
+        color: isAndroid
+          ? resolveVariable('primaryButtonText.color')
+          : '#007AFF', // iOS blue,
         lineHeight: 24,
-        color: '#007AFF', // iOS blue
       },
       cancelText: {
+        color: isAndroid ? resolveVariable('errorText.color') : '#007AFF', // iOS blue,
         textAlign: 'center',
         fontWeight: resolveFontWeight('700'),
-        color: '#007AFF', // iOS blue
       },
     },
 


### PR DESCRIPTION
### Change default color of action sheet options to iOS kind of blue, when Platform is iOS or Web. This is how it looks natively.
![Screenshot 2024-08-28 at 11 02 13](https://github.com/user-attachments/assets/b4cdc32a-ba52-448b-b07e-972c6a24c647)




### Add option to override default styling, from inside implementations. Web is using this to get desired action sheet option text color, to match the one in simulator.
![Screenshot 2024-08-28 at 10 52 19](https://github.com/user-attachments/assets/e07eeaff-b592-4794-9329-d6d93d8d1382)
