### PR TITLE
Feature/adjust web switch component

### DIFF
--- a/components/Switch.js
+++ b/components/Switch.js
@@ -2,19 +2,29 @@ import React from 'react';
 import { Switch as RNSwitch } from 'react-native';
 import PropTypes from 'prop-types';
 import { connectStyle } from '@shoutem/theme';
+import { isWeb } from '../services/platform';
 import { View } from './View';
 
-const Switch = ({ value, onValueChange, style }) => (
-  <View style={style.container}>
-    <RNSwitch
-      trackColor={style.track}
-      thumbColor={style.thumb}
-      ios_backgroundColor={style.track?.false}
-      onValueChange={onValueChange}
-      value={value}
-    />
-  </View>
-);
+const Switch = ({ value, onValueChange, style }) => {
+  const webColors = {
+    trackColor: style.track?.false,
+    activeThumbColor: style.thumb,
+    activeTrackColor: style.track.true,
+  };
+
+  return (
+    <View style={style.container}>
+      <RNSwitch
+        trackColor={isWeb ? style.track?.false : style.track}
+        thumbColor={style.thumb}
+        ios_backgroundColor={style.track?.false}
+        onValueChange={onValueChange}
+        value={value}
+        {...(isWeb && webColors)}
+      />
+    </View>
+  );
+};
 
 Switch.propTypes = {
   onValueChange: PropTypes.func.isRequired,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.12",
+  "version": "7.1.0-beta.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "7.1.0-beta.12",
+      "version": "7.1.0-beta.14",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.12",
+  "version": "7.1.0-beta.14",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Switch component UI diff ios-web:

![Screenshot 2024-08-29 at 11 03 49](https://github.com/user-attachments/assets/b8c93a89-3fe7-4cbe-a757-f61a15a69184)


Added additional props for Switch component, making it looks like iOS native Switch, when running in web.
Other adjustments are done in react-native-web component, which I've created patch for.

In the end, this is the comparison:
![Screenshot 2024-08-29 at 10 26 27](https://github.com/user-attachments/assets/079fe937-55d2-4049-80d1-7df514395fc2)
