### PR TITLE
Fix/toast message height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.17",
+  "version": "7.1.0-beta.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "7.1.0-beta.17",
+      "version": "7.1.0-beta.18",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.17",
+  "version": "7.1.0-beta.18",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -3130,7 +3130,6 @@ export default () => {
       },
       textContainer: {
         flex: 1,
-        height: responsiveHeight(48),
         justifyContent: 'space-between',
       },
       title: {


### PR DESCRIPTION
Removed fixed height for text container inside Toast message.
Toast will now use auto height, depending on the length of the text. Everything is centred as expected.

I thought about adding `minHeight`, setting it to the value toast had before, but I really don't think it's necessary - it even looks better when container is fit to only 2 lines of text (title & message).

If you think old UI looks better for shorter toast messages, let me know, I'll add minHeight. Check last 2 screenshots and their description, for comparison.


Long text (current state)
![Screenshot 2024-09-12 at 20 30 48](https://github.com/user-attachments/assets/cee1033e-fc3d-404d-8250-63c8dc19940f)


Short text (current state)
![Screenshot 2024-09-12 at 20 35 17](https://github.com/user-attachments/assets/fe053f10-de14-48e2-a19d-28a81741ea60)


Short text with minHeight 48 (old state, UI)
![Screenshot 2024-09-12 at 20 35 30](https://github.com/user-attachments/assets/41158c03-ae3d-48d2-abcf-5d85502bfc68)
