### PR TITLE
fix web fonts resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.18",
+  "version": "7.1.0-beta.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "7.1.0-beta.18",
+      "version": "7.1.0-beta.19",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "7.1.0-beta.18",
+  "version": "7.1.0-beta.19",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -72,7 +72,7 @@ export function resolveFontFamily(
   fontWeight = 'normal',
   fontStyle = 'normal',
 ) {
-  if (!isAndroid) {
+  if (isIos) {
     return fontName;
   }
 
@@ -103,7 +103,7 @@ export function resolveFontFamily(
 // being provided to fontWeight will cause the default system font to be used, so we conditionally
 // resolve it.
 export function resolveFontWeight(fontWeight) {
-  if (isAndroid) {
+  if (!isIos) {
     return 'normal';
   }
 
@@ -114,7 +114,7 @@ export function resolveFontWeight(fontWeight) {
 // being provided to fontStyle will cause the default system font to be used, so we conditionally
 // resolve it.
 export function resolveFontStyle(fontStyle) {
-  if (isAndroid) {
+  if (!isIos) {
     return 'normal';
   }
 


### PR DESCRIPTION
We've switched from webpack to esbuild. Esbuild works differently with fonts and these changes are accommodating that difference.