### PR TITLE
set toast max height

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -3153,6 +3153,7 @@ export default () => {
         lineHeight: 16,
         flex: 1,
         flexWrap: 'wrap',
+        maxHeight: resolveVariable('sizes.window.height') / 4,
       },
       buttonContainer: {
         paddingHorizontal: responsiveWidth(12),


### PR DESCRIPTION
In cases where we are loggined full error inside Toast message, it can possible cover up entire screen & more.

Restrict toast message max height to 25% of screen height, unless implementation overrides it.

Before
![Screenshot 2024-10-07 at 14 01 13](https://github.com/user-attachments/assets/c62c124a-c50c-4ff9-9b9d-bb2373edbe17)


After
![Screenshot 2024-10-07 at 14 00 24](https://github.com/user-attachments/assets/5adfcd9c-c66f-413b-9b93-d510988cbd37)
