### PR TITLE
Feature/progress rings

### DIFF
--- a/components/ProgressRings/AnimatedProgressRing.js
+++ b/components/ProgressRings/AnimatedProgressRing.js
@@ -2,22 +2,26 @@
 import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import { useColorInterpolation } from '../../hooks';
+import { useColorAndPercentageInterpolation } from '../../hooks';
 import { DEFAULT_PROGRESS_COLORS, PROGRESS_RING_DEFAULT_PROPS } from './const';
 import ProgressRing from './ProgressRing';
 
 const AnimatedProgressRing = props => {
   const {
-    percentage = PROGRESS_RING_DEFAULT_PROPS.percentage,
+    progressPercentage = PROGRESS_RING_DEFAULT_PROPS.progressPercentage,
     progressColors = DEFAULT_PROGRESS_COLORS,
   } = props;
 
-  const interpolatedColor = useColorInterpolation(progressColors, percentage);
+  const {
+    interpolatedColor,
+    interpolatedPercentage,
+  } = useColorAndPercentageInterpolation(progressColors, progressPercentage);
 
   return (
     <ProgressRing
       {..._.omit(props, ['progressColors'])}
       color={interpolatedColor}
+      progressPercentage={interpolatedPercentage}
     />
   );
 };

--- a/components/ProgressRings/AnimatedProgressRing.js
+++ b/components/ProgressRings/AnimatedProgressRing.js
@@ -1,0 +1,30 @@
+/* eslint-disable react/require-default-props */
+import React from 'react';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import { useColorInterpolation } from '../../hooks';
+import { DEFAULT_PROGRESS_COLORS, PROGRESS_RING_DEFAULT_PROPS } from './const';
+import ProgressRing from './ProgressRing';
+
+const AnimatedProgressRing = props => {
+  const {
+    percentage = PROGRESS_RING_DEFAULT_PROPS.percentage,
+    progressColors = DEFAULT_PROGRESS_COLORS,
+  } = props;
+
+  const interpolatedColor = useColorInterpolation(progressColors, percentage);
+
+  return (
+    <ProgressRing
+      {..._.omit(props, ['progressColors'])}
+      color={interpolatedColor}
+    />
+  );
+};
+
+AnimatedProgressRing.propTypes = {
+  ..._.omit(ProgressRing.propTypes, ['color']),
+  progressColors: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default AnimatedProgressRing;

--- a/components/ProgressRings/ProgressRing.js
+++ b/components/ProgressRings/ProgressRing.js
@@ -1,0 +1,85 @@
+/* eslint-disable react/require-default-props */
+import React from 'react';
+import { Path } from 'react-native-svg';
+import PropTypes from 'prop-types';
+import { changeColorAlpha } from '@shoutem/theme';
+import { PROGRESS_RING_DEFAULT_PROPS } from './const';
+import { circlePath } from './svgCalculations';
+
+const ProgressRing = ({
+  index,
+  width = PROGRESS_RING_DEFAULT_PROPS.width,
+  backgroundWidth = PROGRESS_RING_DEFAULT_PROPS.backgroundWidth,
+  progressLineCap = PROGRESS_RING_DEFAULT_PROPS.progressLineCap,
+  backgroundLineCap = PROGRESS_RING_DEFAULT_PROPS.backgroundLineCap,
+  percentage = PROGRESS_RING_DEFAULT_PROPS.percentage,
+  hasBackgroundColor = PROGRESS_RING_DEFAULT_PROPS.hasBackgroundColor,
+  arcSweepAngle = PROGRESS_RING_DEFAULT_PROPS.arcSweepAngle,
+  size = PROGRESS_RING_DEFAULT_PROPS.size,
+  color = PROGRESS_RING_DEFAULT_PROPS.color,
+}) => {
+  const halfSize = size / 2;
+
+  const maxWidthCircle = backgroundWidth
+    ? Math.max(width, backgroundWidth)
+    : width;
+
+  const radius = halfSize - maxWidthCircle / 2 - index * maxWidthCircle;
+
+  const currentFillAngle =
+    (arcSweepAngle * Math.min(100, Math.max(0, percentage))) / 100;
+
+  const backgroundPath = circlePath(
+    halfSize,
+    halfSize,
+    radius,
+    currentFillAngle,
+    arcSweepAngle,
+  );
+
+  const progressPath = circlePath(
+    halfSize,
+    halfSize,
+    radius,
+    0,
+    currentFillAngle,
+  );
+
+  return (
+    <>
+      {hasBackgroundColor && (
+        <Path
+          d={backgroundPath}
+          stroke={changeColorAlpha(color, 0.2)}
+          strokeWidth={backgroundWidth || width}
+          strokeLinecap={backgroundLineCap}
+          fill="transparent"
+        />
+      )}
+      {percentage > 0 && (
+        <Path
+          d={progressPath}
+          stroke={color}
+          strokeWidth={width}
+          strokeLinecap={progressLineCap}
+          fill="transparent"
+        />
+      )}
+    </>
+  );
+};
+
+ProgressRing.propTypes = {
+  index: PropTypes.number.isRequired,
+  arcSweepAngle: PropTypes.number,
+  backgroundLineCap: PropTypes.string,
+  backgroundWidth: PropTypes.number,
+  color: PropTypes.string,
+  hasBackgroundColor: PropTypes.bool,
+  percentage: PropTypes.number,
+  progressLineCap: PropTypes.string,
+  size: PropTypes.number,
+  width: PropTypes.number,
+};
+
+export default ProgressRing;

--- a/components/ProgressRings/ProgressRing.js
+++ b/components/ProgressRings/ProgressRing.js
@@ -8,26 +8,25 @@ import { circlePath } from './svgCalculations';
 
 const ProgressRing = ({
   index,
-  width = PROGRESS_RING_DEFAULT_PROPS.width,
-  backgroundWidth = PROGRESS_RING_DEFAULT_PROPS.backgroundWidth,
-  progressLineCap = PROGRESS_RING_DEFAULT_PROPS.progressLineCap,
-  backgroundLineCap = PROGRESS_RING_DEFAULT_PROPS.backgroundLineCap,
-  percentage = PROGRESS_RING_DEFAULT_PROPS.percentage,
-  hasBackgroundColor = PROGRESS_RING_DEFAULT_PROPS.hasBackgroundColor,
-  arcSweepAngle = PROGRESS_RING_DEFAULT_PROPS.arcSweepAngle,
+  progressPercentage = PROGRESS_RING_DEFAULT_PROPS.progressPercentage,
   size = PROGRESS_RING_DEFAULT_PROPS.size,
   color = PROGRESS_RING_DEFAULT_PROPS.color,
+  progressLineWidth = PROGRESS_RING_DEFAULT_PROPS.progressLineWidth,
+  backgroundLineWidth = PROGRESS_RING_DEFAULT_PROPS.backgroundLineWidth,
+  progressLineCap = PROGRESS_RING_DEFAULT_PROPS.progressLineCap,
+  backgroundLineCap = PROGRESS_RING_DEFAULT_PROPS.backgroundLineCap,
+  arcSweepAngle = PROGRESS_RING_DEFAULT_PROPS.arcSweepAngle,
 }) => {
   const halfSize = size / 2;
 
-  const maxWidthCircle = backgroundWidth
-    ? Math.max(width, backgroundWidth)
-    : width;
+  const maxWidthCircle = backgroundLineWidth
+    ? Math.max(progressLineWidth, backgroundLineWidth)
+    : progressLineWidth;
 
   const radius = halfSize - maxWidthCircle / 2 - index * maxWidthCircle;
 
   const currentFillAngle =
-    (arcSweepAngle * Math.min(100, Math.max(0, percentage))) / 100;
+    (arcSweepAngle * Math.min(100, Math.max(0, progressPercentage))) / 100;
 
   const backgroundPath = circlePath(
     halfSize,
@@ -47,20 +46,20 @@ const ProgressRing = ({
 
   return (
     <>
-      {hasBackgroundColor && (
+      {backgroundLineWidth > 0 && (
         <Path
           d={backgroundPath}
           stroke={changeColorAlpha(color, 0.2)}
-          strokeWidth={backgroundWidth || width}
+          strokeWidth={backgroundLineWidth || progressLineWidth}
           strokeLinecap={backgroundLineCap}
           fill="transparent"
         />
       )}
-      {percentage > 0 && (
+      {progressPercentage > 0 && (
         <Path
           d={progressPath}
           stroke={color}
-          strokeWidth={width}
+          strokeWidth={progressLineWidth}
           strokeLinecap={progressLineCap}
           fill="transparent"
         />
@@ -73,13 +72,12 @@ ProgressRing.propTypes = {
   index: PropTypes.number.isRequired,
   arcSweepAngle: PropTypes.number,
   backgroundLineCap: PropTypes.string,
-  backgroundWidth: PropTypes.number,
+  backgroundLineWidth: PropTypes.number,
   color: PropTypes.string,
-  hasBackgroundColor: PropTypes.bool,
-  percentage: PropTypes.number,
   progressLineCap: PropTypes.string,
+  progressLineWidth: PropTypes.number,
+  progressPercentage: PropTypes.number,
   size: PropTypes.number,
-  width: PropTypes.number,
 };
 
 export default ProgressRing;

--- a/components/ProgressRings/ProgressRings.js
+++ b/components/ProgressRings/ProgressRings.js
@@ -1,0 +1,68 @@
+import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import { G, Svg } from 'react-native-svg';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import { connectStyle } from '@shoutem/theme';
+import AnimatedProgressRing from './AnimatedProgressRing';
+import ProgressRing from './ProgressRing';
+
+/**
+ * Component rendering given number of rings, which are filled depending on given
+ * percentage values.
+ * It is possible to either specify definite color for each ring by passing ring.color prop,
+ * or give and array of ring.progressColors and component will then interpolate between given
+ * colors, based on given percentage value.
+ */
+const ProgressRings = ({ rings, size, rotation, children, style }) => {
+  const renderRings = useMemo(
+    () =>
+      rings.map((ring, index) => {
+        const ResolvedRingComponent = ring.progressColors
+          ? AnimatedProgressRing
+          : ProgressRing;
+
+        return (
+          <ResolvedRingComponent
+            key={ring.id}
+            index={index}
+            size={size}
+            {...ring}
+          />
+        );
+      }),
+    [rings, size],
+  );
+
+  return (
+    <View style={style.container}>
+      <Svg width={size} height={size}>
+        <G rotation={rotation} originX={size / 2} originY={size / 2}>
+          {renderRings}
+        </G>
+      </Svg>
+      {children && <View style={style.childrenContainer}>{children}</View>}
+    </View>
+  );
+};
+
+ProgressRings.propTypes = {
+  rings: PropTypes.arrayOf(
+    // Omitting color to stop errors, but implementation has to define either color or progressColors,
+    // depending on which component they're using - ProgressRing or AnimatedProgressRing, respectively.
+    PropTypes.shape({ ..._.omit(ProgressRing.propTypes, ['index', 'color']) }),
+  ).isRequired,
+  children: PropTypes.func,
+  rotation: PropTypes.number,
+  size: PropTypes.number,
+  style: PropTypes.object,
+};
+
+ProgressRings.defaultProps = {
+  children: undefined,
+  size: 80,
+  rotation: 0,
+  style: {},
+};
+
+export default connectStyle('shoutem.ui.ProgressRings')(ProgressRings);

--- a/components/ProgressRings/const.js
+++ b/components/ProgressRings/const.js
@@ -1,0 +1,20 @@
+export const DEFAULT_PROGRESS_COLORS = [
+  '#FF0000', // Red
+  '#FF4500', // Orange-Red
+  '#FFA500', // Orange
+  '#FFD700', // Yellow
+  '#ADFF2F', // Yellow-Green
+  '#90EE90', // Light Green
+];
+
+export const PROGRESS_RING_DEFAULT_PROPS = {
+  width: 10,
+  backgroundWidth: 10,
+  progressLineCap: 'round',
+  backgroundLineCap: 'round',
+  percentage: 0.1, // 0.1 so that it shows tiny fill indicator, indicating 0%, better UX/UI than empty.
+  arcSweepAngle: 360,
+  size: 80,
+  hasBackgroundColor: true,
+  color: '#000',
+};

--- a/components/ProgressRings/const.js
+++ b/components/ProgressRings/const.js
@@ -8,13 +8,12 @@ export const DEFAULT_PROGRESS_COLORS = [
 ];
 
 export const PROGRESS_RING_DEFAULT_PROPS = {
-  width: 10,
-  backgroundWidth: 10,
+  progressLineWidth: 10,
+  backgroundLineWidth: 10,
   progressLineCap: 'round',
   backgroundLineCap: 'round',
-  percentage: 0.1, // 0.1 so that it shows tiny fill indicator, indicating 0%, better UX/UI than empty.
+  progressPercentage: 0.1, // 0.1 so that it shows tiny fill indicator, indicating 0%, better UX/UI than empty.
   arcSweepAngle: 360,
   size: 80,
-  hasBackgroundColor: true,
   color: '#000',
 };

--- a/components/ProgressRings/index.js
+++ b/components/ProgressRings/index.js
@@ -1,0 +1,4 @@
+export { default as AnimatedProgressRing } from './AnimatedProgressRing';
+export * from './const';
+export { default as ProgressRing } from './ProgressRing';
+export { default as ProgressRings } from './ProgressRings';

--- a/components/ProgressRings/svgCalculations.js
+++ b/components/ProgressRings/svgCalculations.js
@@ -1,0 +1,26 @@
+const polarToCartesian = (centerX, centerY, radius, angleInDegrees) => {
+  const angleInRadians = ((angleInDegrees - 90) * Math.PI) / 180.0;
+  return {
+    x: centerX + radius * Math.cos(angleInRadians),
+    y: centerY + radius * Math.sin(angleInRadians),
+  };
+};
+
+export const circlePath = (x, y, radius, startAngle, endAngle) => {
+  const start = polarToCartesian(x, y, radius, endAngle * 0.9999999);
+  const end = polarToCartesian(x, y, radius, startAngle);
+  const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1';
+  return [
+    'M',
+    start.x,
+    start.y,
+    'A',
+    radius,
+    radius,
+    0,
+    largeArcFlag,
+    0,
+    end.x,
+    end.y,
+  ].join(' ');
+};

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,1 +1,4 @@
-export { useColorInterpolation } from './useColorInterpolation';
+export {
+  useColorAndPercentageInterpolation,
+  useColorInterpolation,
+} from './useColorAndPercentageInterpolation';

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,0 +1,1 @@
+export { useColorInterpolation } from './useColorInterpolation';

--- a/hooks/useColorAndPercentageInterpolation.js
+++ b/hooks/useColorAndPercentageInterpolation.js
@@ -29,15 +29,15 @@ const resolveInterpolationRange = colors => {
   };
 };
 
-export const useColorInterpolation = (colors, percentage) => {
-  const animatedPercentage = useRef(new Animated.Value(percentage)).current;
+export const useColorInterpolation = (colors, progressPerecentage) => {
+  const animatedPercentage = useRef(new Animated.Value(0)).current;
 
   const [interpolatedColor, setInterpolatedColor] = useState(colors[0]);
 
   useEffect(() => {
     Animated.timing(animatedPercentage, {
-      toValue: percentage,
-      duration: 100,
+      toValue: progressPerecentage,
+      duration: 1000,
       useNativeDriver: false, // Color interpolation requires native driver to be false
     }).start();
 
@@ -54,7 +54,42 @@ export const useColorInterpolation = (colors, percentage) => {
     return () => {
       animatedPercentage.removeListener(listener);
     };
-  }, [percentage, colors, animatedPercentage]);
+  }, [progressPerecentage, colors, animatedPercentage]);
 
   return interpolatedColor;
+};
+
+export const useColorAndPercentageInterpolation = (
+  colors,
+  progressPerecentage,
+) => {
+  const animatedPercentage = useRef(new Animated.Value(0)).current;
+
+  const [interpolatedColor, setInterpolatedColor] = useState(colors[0]);
+  const [interpolatedPercentage, setInterpolatedPercentage] = useState(0);
+
+  useEffect(() => {
+    Animated.timing(animatedPercentage, {
+      toValue: progressPerecentage,
+      duration: 1000,
+      useNativeDriver: false, // Color interpolation requires native driver to be false
+    }).start();
+
+    // Listen to animatedPercentage value changes and update the interpolated color
+    const listener = animatedPercentage.addListener(({ value }) => {
+      const colorInterpolation = animatedPercentage.interpolate(
+        resolveInterpolationRange(colors),
+      );
+
+      // Resolve the interpolated color to a valid color string
+      setInterpolatedColor(colorInterpolation.__getValue());
+      setInterpolatedPercentage(value);
+    });
+
+    return () => {
+      animatedPercentage.removeListener(listener);
+    };
+  }, [progressPerecentage, colors, animatedPercentage]);
+
+  return { interpolatedColor, interpolatedPercentage };
 };

--- a/hooks/useColorInterpolation.js
+++ b/hooks/useColorInterpolation.js
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+import { Animated } from 'react-native';
+
+const resolveInputRange = colors => {
+  if (colors.length === 1) {
+    // If only one color is given, color will always be the same, no matter of percentage.
+    return [0, 100];
+  }
+
+  const numSteps = colors.length - 1;
+  const stepSize = 100 / numSteps;
+
+  return colors.map((_, index) => Math.round(index * stepSize));
+};
+
+const resolveOutputRange = colors => {
+  if (colors.length === 1) {
+    // If only one color is given, color will always be the same, no matter of percentage.
+    return [colors[0], colors[0]];
+  }
+
+  return colors;
+};
+
+const resolveInterpolationRange = colors => {
+  return {
+    inputRange: resolveInputRange(colors),
+    outputRange: resolveOutputRange(colors),
+  };
+};
+
+export const useColorInterpolation = (colors, percentage) => {
+  const animatedPercentage = useRef(new Animated.Value(percentage)).current;
+
+  const [interpolatedColor, setInterpolatedColor] = useState(colors[0]);
+
+  useEffect(() => {
+    Animated.timing(animatedPercentage, {
+      toValue: percentage,
+      duration: 100,
+      useNativeDriver: false, // Color interpolation requires native driver to be false
+    }).start();
+
+    // Listen to animatedPercentage value changes and update the interpolated color
+    const listener = animatedPercentage.addListener(() => {
+      const colorInterpolation = animatedPercentage.interpolate(
+        resolveInterpolationRange(colors),
+      );
+
+      // Resolve the interpolated color to a valid color string
+      setInterpolatedColor(colorInterpolation.__getValue());
+    });
+
+    return () => {
+      animatedPercentage.removeListener(listener);
+    };
+  }, [percentage, colors, animatedPercentage]);
+
+  return interpolatedColor;
+};

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ export { LoadingIndicator } from './components/LoadingIndicator';
 export { NumberInput } from './components/NumberInput';
 export { Overlay } from './components/Overlay';
 export { PageIndicators } from './components/PageIndicators';
+export * from './components/ProgressRings';
 export { Row } from './components/Row';
 export { Screen } from './components/Screen';
 export { ScrollView } from './components/ScrollView';
@@ -71,6 +72,7 @@ export { TouchableOpacity } from './components/TouchableOpacity';
 export { Video } from './components/Video';
 export { View } from './components/View';
 export { YearRangePicker } from './components/YearRangePicker';
+export * from './hooks';
 
 // Helpers
 export { calculateKeyboardOffset, Device, Keyboard } from './helpers';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "8.0.0",
+  "version": "8.1.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "8.0.0",
+      "version": "8.1.0-rc.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "8.1.0-rc.0",
+  "version": "8.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "8.1.0-rc.0",
+      "version": "8.1.0-rc.1",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "8.1.0-rc.0",
+  "version": "8.1.0-rc.1",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "8.0.0",
+  "version": "8.1.0-rc.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -2918,5 +2918,12 @@ export default () => {
         maxHeight: responsiveHeight(20),
       },
     },
+
+    'shoutem.ui.ProgressRings': {
+      container: { justifyContent: 'center', alignItems: 'center' },
+      childrenContainer: {
+        position: 'absolute',
+      },
+    },
   };
 };


### PR DESCRIPTION
## Summary
- Add `ProgressRings` component for rendering filling ring UI representation of given percentage
  - There are 2 concepts available: `ProgressRing` and `AnimatedProgressRing`
  - If single, definite color is given as prop to ProgressRings `rings`, we'll render `ProgressRing` component colored as specified
  - If array of `progressColors` is given as prop, then `AnimatedProgressRing` is used as main component and it interpolates between given `progressColor`s based on given percentage value
  - We could potentially extend later component with filling animation, but I couldn't figure it out now, I'm also out of time. I've probably had issues with re-rendering in my implementation
- Add `useColorInterpolation` hook which resolves color based on given colors and values. For progress rings case, this is used to get the same color for rings & outside rings component, but in general, it can be used in various scenarios


<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/c3e2582a-e8ec-459a-99b4-4095a6cfbdd7" width="400" /></td>
<td><img src="https://github.com/user-attachments/assets/0e53eb47-09f5-450e-a1da-0810dcb48bcb" width="400" /></td>
<td><img src="https://github.com/user-attachments/assets/a7649e8d-76ca-4307-aa1a-e293f5665101" width="400" /></td>
<td><img src="https://github.com/user-attachments/assets/dedeb713-c665-49ea-8c56-182262a28beb" width="400" /></td>
</tr>
</table>


https://github.com/user-attachments/assets/1cb23f5a-4878-4a49-a157-d683340346a8

