### PR TITLE
Fix/improve action sheet UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "8.2.5",
+  "version": "8.2.6-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "8.2.5",
+      "version": "8.2.6-rc.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "8.2.5",
+  "version": "8.2.6-rc.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -2407,8 +2407,11 @@ export default () => {
         paddingHorizontal: 20,
         paddingVertical: 16,
         borderBottomWidth: 1,
-        borderColor: 'rgba(130, 130, 130, 0.1)',
         alignItems: 'center',
+        backgroundColor: resolveVariable('primaryButtonBackgroundColor'),
+        borderColor: resolveVariable('primaryButtonBorderColor'),
+        borderWidth: StyleSheet.hairlineWidth,
+        borderRadius: 13,
       },
       text: {
         fontSize: 15,


### PR DESCRIPTION
Adjusted background color on Action Item to cover for all default Shoutem theme options.

Before - we were setting text color to primary button text color value, but we weren't controling container background color, which would be about the same as text color.

Solution:
Explicitly set colors, so that all colors follow primary button colors, from theme.

Before:
![Screenshot 2025-07-03 at 10 41 25](https://github.com/user-attachments/assets/4735e582-84e3-40e6-954a-cca1369f8c0e)

Now
![Screenshot 2025-07-03 at 10 40 58](https://github.com/user-attachments/assets/a5d99a4b-ee43-42d6-9b00-6c3c0c98eabd)
