### PR TITLE
Feat/screen safe area bottom inset

### DIFF
--- a/components/Screen.js
+++ b/components/Screen.js
@@ -1,8 +1,17 @@
+import React from 'react';
 import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { connectAnimation } from '@shoutem/animation';
 import { connectStyle } from '@shoutem/theme';
 
-const AnimatedScreen = connectAnimation(View);
+const SafeAreaAwareView = ({ style, ...rest }) => {
+  const insets = useSafeAreaInsets();
+  const safeAreaStyle = { paddingBottom: insets.bottom };
+
+  return <View {...rest} style={[style, safeAreaStyle]} />;
+};
+
+const AnimatedScreen = connectAnimation(SafeAreaAwareView);
 const Screen = connectStyle('shoutem.ui.Screen')(AnimatedScreen);
 
 export { Screen };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "9.0.7",
+  "version": "9.1.0",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -977,12 +977,6 @@ export default () => {
         paddingBottom: HOME_INDICATOR_PADDING,
       },
 
-      'shoutem.ui.ListView': {
-        listContent: {
-          paddingBottom: HOME_INDICATOR_PADDING,
-        },
-      },
-
       backgroundColor: resolveVariable('backgroundColor'),
       flex: 1,
     },


### PR DESCRIPTION
## Summary
`<Screen>` now adds `paddingBottom: useSafeAreaInsets().bottom` to its
outer container automatically, so content stays clear of the iOS home
indicator and the Android system gesture bar without consumers having to
remember the `.with-notch-padding` / `.with-home-indicator-padding`
styleName on every screen.

Implemented as a small function-component wrapper around `View`. Style
array order `[style, safeAreaStyle]` makes the live inset override any
incoming `paddingBottom` from theme.

Also removes the nested `'shoutem.ui.Screen' → 'shoutem.ui.ListView' →
listContent → paddingBottom: HOME_INDICATOR_PADDING` rule from `theme.js`
— with the new Screen-level padding, that rule would compound and
double-pad list screens. The padding now lives in one place: Screen's
outer container.

**Why not `SafeAreaView`:** its default edge mode is *additive*
(`paddingBottom = current + insets.bottom`), which would double-pad
consumers using the existing styleName variants.

**Backward compatible:** `.with-notch-padding` / `.with-home-indicator-padding`
styleNames continue to work — they become functionally redundant, not
broken. Consumers must already render `<SafeAreaProvider>` at the app
root (standard `react-native-safe-area-context` requirement).

**Context-aware:** inside a bottom-tab navigator the hook reports
`bottom: 0` (tab bar absorbs the inset), so no double-padding there.