### PR TITLE
feat/Add style slot  to date time picker

### DIFF
--- a/components/DateTimePicker.js
+++ b/components/DateTimePicker.js
@@ -122,7 +122,7 @@ class DateTimePicker extends PureComponent {
           style={style.textContainer}
           onPress={this.handleShowPicker}
         >
-          <Text>{textValue}</Text>
+          <Text style={style.text}>{textValue}</Text>
         </TouchableOpacity>
         <TouchableOpacity
           onPress={this.handleShowPicker}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shoutem/ui",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shoutem/ui",
-      "version": "9.1.1",
+      "version": "9.1.2",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/ui",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Styleable set of components for React Native applications",
   "scripts": {
     "lint": "eslint .",

--- a/theme.js
+++ b/theme.js
@@ -2680,6 +2680,7 @@ export default () => {
       modalButton: { width: 100, margin: 'auto' },
       modalButtonContainer: { height: 80 },
       modalContainer: { backgroundColor: '#FFFFFF' },
+      text: {},
       textContainer: {
         borderColor: '#C2C2C2',
         borderWidth: 1,


### PR DESCRIPTION
## Summary

Add a `text` style slot to `DateTimePicker` so consumers can theme the button-face text.

Every visual element in the picker already has a named style slot — `textContainer`, `buttonContainer`, `icon`, `modalContainer`, `modalButton`, `modalButtonContainer` — except the button-face `<Text>` that displays the formatted date/time. This PR closes that gap, following the `text` slot naming used elsewhere in the package (`ActionSheet`, `ActionSheetOption`, `TabMenu`, `TabMenuItem`, `SuccessToast`, `AnimatedScrollingText`).